### PR TITLE
Make GBIF registry sync incremental and far cheaper

### DIFF
--- a/api/src/main/java/life/catalogue/api/model/DatasetGBIF.java
+++ b/api/src/main/java/life/catalogue/api/model/DatasetGBIF.java
@@ -1,10 +1,13 @@
 package life.catalogue.api.model;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
 public class DatasetGBIF extends DatasetSimple {
   private UUID gbifKey;
+  // the GBIF registry modified timestamp we last synced, used to skip unchanged datasets
+  private LocalDateTime gbifModified;
 
   public UUID getGbifKey() {
     return gbifKey;
@@ -14,17 +17,26 @@ public class DatasetGBIF extends DatasetSimple {
     this.gbifKey = gbifKey;
   }
 
+  public LocalDateTime getGbifModified() {
+    return gbifModified;
+  }
+
+  public void setGbifModified(LocalDateTime gbifModified) {
+    this.gbifModified = gbifModified;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof DatasetGBIF)) return false;
     if (!super.equals(o)) return false;
 
     DatasetGBIF that = (DatasetGBIF) o;
-    return Objects.equals(gbifKey, that.gbifKey);
+    return Objects.equals(gbifKey, that.gbifKey)
+           && Objects.equals(gbifModified, that.gbifModified);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), gbifKey);
+    return Objects.hash(super.hashCode(), gbifKey, gbifModified);
   }
 }

--- a/core/src/main/java/life/catalogue/gbifsync/DatasetPager.java
+++ b/core/src/main/java/life/catalogue/gbifsync/DatasetPager.java
@@ -11,7 +11,11 @@ import life.catalogue.parser.*;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -22,8 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 
 import de.undercouch.citeproc.csl.CSLType;
@@ -41,62 +43,41 @@ public class DatasetPager {
   private static final Pattern SUFFIX_KEY = Pattern.compile("^(.+)-(\\d+)$");
   private static final Pattern domain = Pattern.compile("([^.]+)\\.[a-z]+$", Pattern.CASE_INSENSITIVE);
   private static final int MAX_OFFSET = 100_000;
+  // bounded retry backoff for slow/timing-out GBIF pages - seconds, not minutes, so one bad page cannot stall the whole sync
+  private static final int MAX_PAGE_TRIES = 6;
+  private static final long BACKOFF_BASE_SECONDS = 2;
+  private static final long BACKOFF_MAX_SECONDS = 60;
 
   private final Page page = new Page(100);
   private boolean hasNext = true;
   final WebTarget dataset;
   final WebTarget datasets;
-  final WebTarget organization;
-  final WebTarget installation;
   final Client client;
-  private final LoadingCache<UUID, Agent> publisherCache;
-  private final LoadingCache<UUID, Agent> hostCache;
+  private final GbifRegistryCache registry;
   private final Set<UUID> articlePublishers;
   private final Set<UUID> articleHostInstallations;
   private final Set<UUID> blockedDatasets;
   private final LocalDate since;
 
+  /**
+   * Convenience constructor that builds its own (un-shared) registry cache.
+   * Mostly for tests and standalone use - the sync jobs pass a shared {@link GbifRegistryCache}.
+   */
   public DatasetPager(Client client, GbifConfig gbif, @Nullable LocalDate since) {
+    this(client, gbif, since, new GbifRegistryCache(client, gbif));
+  }
+
+  public DatasetPager(Client client, GbifConfig gbif, @Nullable LocalDate since, GbifRegistryCache registry) {
     this.client = client;
     this.since = since;
+    this.registry = registry;
     articlePublishers = Set.copyOf(gbif.articlePublishers);
     articleHostInstallations = Set.copyOf(gbif.articleHostInstallations);
     blockedDatasets = Set.copyOf(gbif.blockedDatasets);
     dataset = client.target(UriBuilder.fromUri(gbif.api).path("/dataset"));
     datasets = client.target(UriBuilder.fromUri(gbif.api).path("/dataset"))
         .queryParam("type", "CHECKLIST");
-    organization = client.target(UriBuilder.fromUri(gbif.api).path("/organization/"));
-    installation = client.target(UriBuilder.fromUri(gbif.api).path("/installation/"));
-    publisherCache = Caffeine.newBuilder()
-                             .maximumSize(2000)
-                             .build(this::loadPublisher);
-    hostCache = Caffeine.newBuilder()
-                        .maximumSize(2000)
-                        .build(this::loadHost);
     LOG.info("Created dataset pager for {}", datasets.getUri());
-  }
-
-  private Agent loadPublisher(UUID key) {
-    WebTarget pubDetail = organization.path(key.toString());
-    LOG.debug("Retrieve organization {}", pubDetail.getUri());
-    GAgent p = pubDetail.request()
-                        .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .get(GAgent.class);
-    return p.toAgent();
-  }
-
-  private Agent loadHost(UUID key) {
-    WebTarget insDetail = installation.path(key.toString());
-    LOG.debug("Retrieve installation {}", insDetail.getUri());
-    GInstallation ins = insDetail.request()
-                                 .accept(MediaType.APPLICATION_JSON_TYPE)
-                                 .get(GInstallation.class);
-    if (ins != null && ins.organizationKey != null) {
-      var host = publisherCache.get(ins.organizationKey);
-      host.setNote("Host");
-      return host;
-    }
-    return null;
   }
 
   /**
@@ -163,7 +144,7 @@ public class DatasetPager {
   protected List<GbifDataset> next() throws InterruptedException {
     LOG.debug("retrieve {}", page);
     int tries = 0;
-    while (tries < 12) {
+    while (tries < MAX_PAGE_TRIES) {
       try {
         GResp resp = datasetPage()
           .request()
@@ -176,12 +157,21 @@ public class DatasetPager {
       } catch (Exception e) {
         tries++;
         LOG.warn("Paging error {}: {}", page, e.getMessage(), e);
-        TimeUnit.MINUTES.sleep(tries * tries);
+        if (tries < MAX_PAGE_TRIES) {
+          TimeUnit.SECONDS.sleep(backoffSeconds(tries));
+        }
       }
     }
     LOG.error("Reached maximum retries for page {}", page);
     nextPage();
     return Collections.emptyList();
+  }
+
+  /** Bounded exponential backoff in seconds with jitter (2,4,8,16,32, capped at 60), so a slow GBIF page can never stall the sync for minutes. */
+  @VisibleForTesting
+  static long backoffSeconds(int tries) {
+    long secs = Math.min(BACKOFF_MAX_SECONDS, BACKOFF_BASE_SECONDS * (1L << (tries - 1)));
+    return secs + ThreadLocalRandom.current().nextLong(secs / 2 + 1);
   }
 
   /**
@@ -214,9 +204,17 @@ public class DatasetPager {
     Integer clbDatasetKey;
     // identifier keys for just the CLB_DATASET_KEY entries
     final List<Integer> identifierKeys = new ArrayList<>();
+    // raw GBIF dataset kept for lazy agent resolution, see DatasetPager#resolveAgents
+    GDataset src;
+    // GBIF registry modified timestamp (UTC), used to skip datasets that have not changed since the last sync
+    LocalDateTime modified;
 
     public Integer getKey() {
       return dataset.getKey();
+    }
+
+    public LocalDateTime getModified() {
+      return modified;
     }
 
     public UUID getGbifKey() {
@@ -241,6 +239,9 @@ public class DatasetPager {
   }
 
   /**
+   * Maps all dataset metadata that is already contained in the paged GBIF response, without hitting the
+   * registry organisation/installation endpoints. The publisher, host and contact agents are resolved
+   * lazily in {@link #resolveAgents(GbifDataset)} only for datasets that are new or have changed.
    * @return converted dataset or NULL if illegitimate
    */
   private GbifDataset convert(GDataset g) {
@@ -253,11 +254,11 @@ public class DatasetPager {
     }
 
     GbifDataset d = new GbifDataset();
+    d.src = g;
+    d.modified = g.modified;
     d.dataset.setPrivat(false);
     d.dataset.setGbifKey(g.key);
     d.dataset.setGbifPublisherKey(g.publishingOrganizationKey);
-    d.dataset.setPublisher(publisherCache.get(g.publishingOrganizationKey));
-    d.dataset.addContributor(hostCache.get(g.installationKey));
     d.dataset.setTitle(g.title);
     d.dataset.setDescription(g.description);
     DOI.parse(g.doi).ifPresent(doi -> d.dataset.addIdentifier(new Identifier(doi)));
@@ -292,6 +293,24 @@ public class DatasetPager {
     d.dataset.setGeographicScope(coverage(g.geographicCoverages));
     d.dataset.setTaxonomicScope(coverage(g.taxonomicCoverages));
     d.dataset.setTemporalScope(coverage(g.temporalCoverages));
+    addIdentifiers(d, g.key, g.identifiers);
+    d.dataset.setSource(toSource(g.bibliographicCitations));
+    //d.setNotes(toNotes(g.comments));
+    d.dataset.setIssued(g.pubDate);
+    d.dataset.setCreated(LocalDateTime.now());
+    LOG.debug("Dataset {} converted: {}", g.key, g.title);
+    return d;
+  }
+
+  /**
+   * Resolves the publisher and host organisations and the dataset contacts from the GBIF registry.
+   * This is the only part of the conversion that hits the slow registry organisation/installation
+   * endpoints, so it is called lazily - only for datasets that are new or have actually changed.
+   */
+  public void resolveAgents(GbifDataset d) {
+    GDataset g = d.src;
+    d.dataset.setPublisher(registry.publisher(g.publishingOrganizationKey));
+    d.dataset.addContributor(registry.host(g.installationKey));
     // convert contact and authors based on contact type: https://github.com/gbif/gbif-api/blob/master/src/main/java/org/gbif/api/vocabulary/ContactType.java
     // Not mapped: PUBLISHER,DISTRIBUTOR,METADATA_AUTHOR,TECHNICAL_POINT_OF_CONTACT,OWNER,PROCESSOR,USER,PROGRAMMER,DATA_ADMINISTRATOR,SYSTEM_ADMINISTRATOR,HEAD_OF_DELEGATION,TEMPORARY_HEAD_OF_DELEGATION,ADDITIONAL_DELEGATE,TEMPORARY_DELEGATE,REGIONAL_NODE_REPRESENTATIVE,NODE_MANAGER,NODE_STAFF
     var contacts = byType(g.contacts, "POINT_OF_CONTACT", "ADMINISTRATIVE_POINT_OF_CONTACT");
@@ -309,13 +328,6 @@ public class DatasetPager {
                                                       && !Objects.equals(d.dataset.getPublisher(), a))
                                          .collect(Collectors.toList());
     d.dataset.setContributor(contributors);
-    addIdentifiers(d, g.key, g.identifiers);
-    d.dataset.setSource(toSource(g.bibliographicCitations));
-    //d.setNotes(toNotes(g.comments));
-    d.dataset.setIssued(g.pubDate);
-    d.dataset.setCreated(LocalDateTime.now());
-    LOG.debug("Dataset {} converted: {}", g.key, g.title);
-    return d;
   }
 
   private List<Citation> toSource(List<GCitation> bibliographicCitations) {
@@ -469,6 +481,8 @@ public class DatasetPager {
     public List<GCoverage> temporalCoverages;
     public String license;
     public FuzzyDate pubDate;
+    // the GBIF registry modified timestamp (UTC), used to detect datasets that changed since the last sync
+    public LocalDateTime modified;
     public List<GEndpoint> endpoints;
     public List<GAgent> contacts;
     public List<GComment> comments;
@@ -481,6 +495,26 @@ public class DatasetPager {
       } catch (UnparsableException e) {
         LOG.warn("Failed to parse pubDate {}", pubDate, e);
       }
+    }
+
+    public void setModified(String modified) {
+      this.modified = parseGbifDateTime(modified);
+    }
+  }
+
+  /**
+   * Parses a GBIF ISO-8601 timestamp with offset (e.g. 2026-06-09T20:04:21.795+00:00) into a UTC LocalDateTime.
+   * @return the UTC LocalDateTime or null if blank/unparsable
+   */
+  static LocalDateTime parseGbifDateTime(String s) {
+    if (StringUtils.isBlank(s)) {
+      return null;
+    }
+    try {
+      return OffsetDateTime.parse(s).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    } catch (DateTimeParseException e) {
+      LOG.warn("Failed to parse GBIF datetime {}", s);
+      return null;
     }
   }
 
@@ -529,6 +563,8 @@ public class DatasetPager {
     public String key;
     public String type;
     public String title;
+    // organisation description, only populated for publisher/host organisations (see GbifRegistryCache)
+    public String description;
     public String firstName;
     public String lastName;
     public List<String> position;

--- a/core/src/main/java/life/catalogue/gbifsync/GbifRegistryCache.java
+++ b/core/src/main/java/life/catalogue/gbifsync/GbifRegistryCache.java
@@ -1,0 +1,132 @@
+package life.catalogue.gbifsync;
+
+import life.catalogue.api.model.Agent;
+import life.catalogue.api.model.Publisher;
+import life.catalogue.api.vocab.area.Country;
+import life.catalogue.config.GbifConfig;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Shared, long lived cache of GBIF registry organisations and installations.
+ * A single instance is reused across all GBIF sync runs (dataset and publisher syncs) so the same
+ * publisher/host organisations are not re-fetched from the slow registry on every run. The raw
+ * organisation is cached once and used both as a publisher {@link Agent} (for datasets) and as a
+ * {@link Publisher} entity (for the publisher sync), so each organisation is fetched at most once
+ * per TTL window regardless of which sync needs it. Entries expire after a configurable number of
+ * hours so organisation metadata still refreshes over time.
+ */
+public class GbifRegistryCache {
+  private static final Logger LOG = LoggerFactory.getLogger(GbifRegistryCache.class);
+  private static final long DEFAULT_TTL_HOURS = 12;
+  private static final int MAX_SIZE = 10_000;
+
+  private final WebTarget organization;
+  private final WebTarget installation;
+  // raw organisation as returned by GBIF - the single source for both publisher Agents and Publisher entities
+  private final LoadingCache<UUID, DatasetPager.GAgent> orgCache;
+  // installation key -> host Agent (derived from the installation's organisation)
+  private final LoadingCache<UUID, Agent> hostCache;
+
+  public GbifRegistryCache(Client client, GbifConfig cfg) {
+    this.organization = client.target(UriBuilder.fromUri(cfg.api).path("/organization/"));
+    this.installation = client.target(UriBuilder.fromUri(cfg.api).path("/installation/"));
+    long ttl = cfg.registryCacheHours > 0 ? cfg.registryCacheHours : DEFAULT_TTL_HOURS;
+    this.orgCache = Caffeine.newBuilder()
+      .maximumSize(MAX_SIZE)
+      .expireAfterWrite(ttl, TimeUnit.HOURS)
+      .build(this::loadOrg);
+    this.hostCache = Caffeine.newBuilder()
+      .maximumSize(MAX_SIZE)
+      .expireAfterWrite(ttl, TimeUnit.HOURS)
+      .build(this::loadHost);
+    LOG.info("Created GBIF registry cache with {}h TTL", ttl);
+  }
+
+  /** @return the publisher organisation as an Agent, or null if the key is null or has no usable name */
+  public @Nullable Agent publisher(@Nullable UUID orgKey) {
+    if (orgKey == null) return null;
+    DatasetPager.GAgent g = orgCache.get(orgKey);
+    return g == null ? null : g.toAgent();
+  }
+
+  /** @return the publisher organisation as a Publisher entity, or null if the key is null */
+  public @Nullable Publisher publisherEntity(@Nullable UUID orgKey) {
+    if (orgKey == null) return null;
+    DatasetPager.GAgent g = orgCache.get(orgKey);
+    return g == null ? null : toPublisher(orgKey, g);
+  }
+
+  /** @return the host organisation behind an installation as an Agent, or null */
+  public @Nullable Agent host(@Nullable UUID installationKey) {
+    if (installationKey == null) return null;
+    return hostCache.get(installationKey);
+  }
+
+  private DatasetPager.GAgent loadOrg(UUID key) {
+    WebTarget t = organization.path(key.toString());
+    LOG.debug("Retrieve organization {}", t.getUri());
+    return t.request()
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .get(DatasetPager.GAgent.class);
+  }
+
+  private Agent loadHost(UUID installationKey) {
+    WebTarget t = installation.path(installationKey.toString());
+    LOG.debug("Retrieve installation {}", t.getUri());
+    DatasetPager.GInstallation ins = t.request()
+                                      .accept(MediaType.APPLICATION_JSON_TYPE)
+                                      .get(DatasetPager.GInstallation.class);
+    if (ins != null && ins.organizationKey != null) {
+      Agent host = publisher(ins.organizationKey);
+      if (host != null) {
+        host.setNote("Host");
+      }
+      return host;
+    }
+    return null;
+  }
+
+  private static Publisher toPublisher(UUID key, DatasetPager.GAgent g) {
+    Publisher p = new Publisher();
+    p.setKey(key);
+    p.setTitle(g.title);
+    p.setDescription(g.description);
+    p.setHomepage(StringUtils.trimToNull(g.firstHomepage()));
+    p.setCity(g.city);
+    p.setProvince(g.province);
+    p.setCountry(country(g.country));
+    p.setLatitude(parseDouble(g.latitude));
+    p.setLongitude(parseDouble(g.longitude));
+    return p;
+  }
+
+  private static String country(String iso) {
+    if (StringUtils.isBlank(iso)) return null;
+    return Country.fromIsoCode(iso).map(Country::getName).orElse(iso);
+  }
+
+  private static Double parseDouble(String s) {
+    if (StringUtils.isBlank(s)) return null;
+    try {
+      return Double.valueOf(s);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/core/src/main/java/life/catalogue/gbifsync/GbifSyncJob.java
+++ b/core/src/main/java/life/catalogue/gbifsync/GbifSyncJob.java
@@ -1,6 +1,7 @@
 package life.catalogue.gbifsync;
 
 import life.catalogue.api.model.Dataset;
+import life.catalogue.api.model.DatasetGBIF;
 import life.catalogue.api.model.DatasetWithSettings;
 import life.catalogue.api.vocab.DatasetOrigin;
 import life.catalogue.api.vocab.DatasetType;
@@ -23,6 +24,8 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import jakarta.ws.rs.client.Client;
@@ -42,26 +45,31 @@ public class GbifSyncJob extends GlobalBlockingJob {
   private final SqlSessionFactory sessionFactory;
   private final DatasetDao dao;
   private final GbifConfig cfg;
+  private final GbifRegistryCache registry;
   private Set<UUID> keys;
   private int created;
   private int updated;
   private int deleted;
+  private int skipped;
   private boolean incremental;
   private DatasetPager pager;
+  // existing ChecklistBank datasets that carry a GBIF key, preloaded once per run to avoid per-dataset DB lookups
+  private Map<UUID, DatasetGBIF> existingByGbif = Collections.emptyMap();
 
   /**
    *  Syncs updates of today
    **/
-  public GbifSyncJob(GbifConfig cfg, Client client, DatasetDao ddao, SqlSessionFactory sessionFactory, int userKey, boolean incremental) {
-    this(cfg, client, ddao, sessionFactory, userKey, Collections.emptySet(), incremental);
+  public GbifSyncJob(GbifConfig cfg, Client client, DatasetDao ddao, SqlSessionFactory sessionFactory, GbifRegistryCache registry, int userKey, boolean incremental) {
+    this(cfg, client, ddao, sessionFactory, registry, userKey, Collections.emptySet(), incremental);
   }
 
-  public GbifSyncJob(GbifConfig cfg, Client client, DatasetDao ddao, SqlSessionFactory sessionFactory, int userKey, Set<UUID> keys, boolean incremental) {
+  public GbifSyncJob(GbifConfig cfg, Client client, DatasetDao ddao, SqlSessionFactory sessionFactory, GbifRegistryCache registry, int userKey, Set<UUID> keys, boolean incremental) {
     super(userKey, JobPriority.HIGH);
     this.cfg = cfg;
     this.client = client;
     this.dao = ddao;
     this.sessionFactory = sessionFactory;
+    this.registry = registry;
     this.keys = keys == null ? new HashSet<>() : keys;
     this.incremental = incremental;
     this.datasetTarget = client.target(UriBuilder
@@ -88,7 +96,9 @@ public class GbifSyncJob extends GlobalBlockingJob {
         since = LocalDate.now();
       }
     }
-    pager = new DatasetPager(client, cfg, since);
+    pager = new DatasetPager(client, cfg, since, registry);
+    // preload all existing GBIF-keyed datasets once so we avoid a DB lookup per dataset and can skip unchanged ones
+    existingByGbif = loadExisting();
     // remove any existing datasets that are blocked - the pager skips them, so they won't be recreated below
     deleteBlocked();
     if (!keys.isEmpty()) {
@@ -96,7 +106,24 @@ public class GbifSyncJob extends GlobalBlockingJob {
     } else {
       syncAll();
     }
-    LOG.info("{} datasets added, {} updated, {} deleted", created, updated, deleted);
+    LOG.info("{} datasets added, {} updated, {} skipped unchanged, {} deleted", created, updated, skipped, deleted);
+  }
+
+  /**
+   * Loads all non-deleted ChecklistBank datasets that carry a GBIF key into a map keyed by GBIF UUID.
+   * Each record carries the GBIF modified timestamp we last synced, used to skip unchanged datasets.
+   */
+  private Map<UUID, DatasetGBIF> loadExisting() {
+    Map<UUID, DatasetGBIF> map = new HashMap<>();
+    try (SqlSession session = sessionFactory.openSession()) {
+      for (DatasetGBIF d : session.getMapper(DatasetMapper.class).listGBIF()) {
+        if (d.getGbifKey() != null) {
+          map.put(d.getGbifKey(), d);
+        }
+      }
+    }
+    LOG.info("Loaded {} existing GBIF datasets from ChecklistBank", map.size());
+    return map;
   }
 
   /**
@@ -119,24 +146,22 @@ public class GbifSyncJob extends GlobalBlockingJob {
     for (UUID key : keys) {
       var gbif = pager.get(key);
       if (gbif != null) {
-        DatasetWithSettings curr = dao.getWithSettings(gbif.getGbifKey());
-        sync(gbif, curr);
+        sync(gbif, existingByGbif.get(gbif.getGbifKey()));
       }
     }
   }
 
   private void syncAll() throws Exception {
-    final IntSet keys = new IntOpenHashSet();
+    final IntSet seenKeys = new IntOpenHashSet();
     int count = pager.count();
     LOG.info("Start {} sync of {} datasets from GBIF registry {}", incremental ? "incremental" : "full", count, cfg.api);
     while (pager.hasNext()) {
       List<DatasetPager.GbifDataset> page = pager.next();
       LOG.debug("Received page {} with {} datasets from GBIF", pager.currPageNumber(), page.size());
       for (DatasetPager.GbifDataset gbif : page) {
-        DatasetWithSettings curr = dao.getWithSettings(gbif.getGbifKey());
-        Integer datasetKey = sync(gbif, curr);
+        Integer datasetKey = sync(gbif, existingByGbif.get(gbif.getGbifKey()));
         if (datasetKey != null) {
-          keys.add(datasetKey);
+          seenKeys.add(datasetKey.intValue());
         }
       }
     }
@@ -146,7 +171,7 @@ public class GbifSyncJob extends GlobalBlockingJob {
       try (SqlSession session = sessionFactory.openSession()) {
         var dm = session.getMapper(DatasetMapper.class);
         dm.listKeysGBIF().forEach(key -> {
-          if (!keys.contains((int)key)) {
+          if (!seenKeys.contains((int)key)) {
             // this key was not seen in this registry sync round before - delete it
             Dataset d = dm.get(key);
             if (d.getOrigin() != DatasetOrigin.EXTERNAL) {
@@ -165,18 +190,27 @@ public class GbifSyncJob extends GlobalBlockingJob {
   }
 
   /**
-   * @return the dataset key in CLB even if locked or null if it never was synced
+   * @return the dataset key in CLB even if locked/unchanged, or null if it never was synced
    */
-  private Integer sync(DatasetPager.GbifDataset gbif, DatasetWithSettings curr) throws InterruptedException {
+  private Integer sync(DatasetPager.GbifDataset gbif, DatasetGBIF existing) throws InterruptedException {
     Exceptions.interruptIfCancelled("GBIF sync interrupted");
     // start out with the existing key if there is one
-    Integer key = curr == null ? null : curr.getKey();
+    Integer key = existing == null ? null : existing.getKey();
+    // skip datasets that have not changed in the GBIF registry since we last synced them.
+    // this avoids the slow registry organisation/installation lookups and the DB read+write for unchanged datasets.
+    if (existing != null && isUnchanged(gbif, existing)) {
+      skipped++;
+      return key;
+    }
     try {
       // a GBIF license is required
       if (gbif.dataset.getLicense() == null || !gbif.dataset.getLicense().isCreativeCommons()) {
         LOG.warn("GBIF dataset {} without a creative commons license: {}", gbif.getGbifKey(), gbif.dataset.getTitle());
 
       } else {
+        // the dataset is new or changed - only now resolve publisher/host/contacts from the slow registry
+        pager.resolveAgents(gbif);
+        DatasetWithSettings curr = existing == null ? null : dao.getWithSettings(gbif.getGbifKey());
 
         if (curr == null) {
           // create new dataset
@@ -228,11 +262,38 @@ public class GbifSyncJob extends GlobalBlockingJob {
             addDatasetKey(gbif.getGbifKey(), key);
           }
         }
+        // remember the GBIF modified timestamp we just synced so this dataset is skipped next run until it changes again.
+        // done for create/update/locked/no-op alike so we never re-examine a dataset we have already processed.
+        if (key != null) {
+          persistGbifModified(key, gbif.getModified());
+        }
       }
     } catch (Exception e) {
       LOG.error("Failed to sync GBIF dataset {} >{}<", gbif.getGbifKey(), gbif.getTitle(), e);
     }
     return key;
+  }
+
+  /**
+   * @return true if the GBIF dataset has not been modified in the registry since we last synced it.
+   *   When either timestamp is unknown (e.g. datasets synced before delta tracking) we treat it as changed
+   *   so it gets processed once and its watermark recorded.
+   */
+  @VisibleForTesting
+  static boolean isUnchanged(DatasetPager.GbifDataset gbif, DatasetGBIF existing) {
+    LocalDateTime gMod = gbif.getModified();
+    LocalDateTime stored = existing.getGbifModified();
+    return gMod != null && stored != null && !gMod.isAfter(stored);
+  }
+
+  /** Persists the GBIF registry modified timestamp we last synced for a dataset. */
+  private void persistGbifModified(int key, LocalDateTime modified) {
+    if (modified == null) {
+      return;
+    }
+    try (SqlSession session = sessionFactory.openSession(true)) {
+      session.getMapper(DatasetMapper.class).updateGbifModified(key, modified);
+    }
   }
 
   private void addDatasetKey(UUID key, Integer datasetKey) {

--- a/core/src/main/java/life/catalogue/gbifsync/GbifSyncManager.java
+++ b/core/src/main/java/life/catalogue/gbifsync/GbifSyncManager.java
@@ -36,6 +36,8 @@ public class GbifSyncManager implements Managed {
   private final DatasetDao ddao;
   private final SqlSessionFactory sessionFactory;
   private final Client client;
+  // shared across all sync runs so publisher/host organisations are only fetched once per TTL window
+  private final GbifRegistryCache registry;
   private final List<ScheduledFuture<?>> futures = new ArrayList<>();
 
   public GbifSyncManager(GbifConfig gbif, ImporterConfig iCfg, DatasetDao ddao, SqlSessionFactory sessionFactory, Client client) {
@@ -44,6 +46,11 @@ public class GbifSyncManager implements Managed {
     this.ddao = ddao;
     this.sessionFactory = sessionFactory;
     this.client = client;
+    this.registry = new GbifRegistryCache(client, gbif);
+  }
+
+  public GbifRegistryCache getRegistryCache() {
+    return registry;
   }
 
   @Override
@@ -52,7 +59,7 @@ public class GbifSyncManager implements Managed {
   }
   
   public void syncNow() {
-    Runnable job = new GbifSyncJob(cfg, client, ddao, sessionFactory, Users.GBIF_SYNC, true);
+    Runnable job = new GbifSyncJob(cfg, client, ddao, sessionFactory, registry, Users.GBIF_SYNC, true);
     job.run();
   }
 
@@ -71,14 +78,14 @@ public class GbifSyncManager implements Managed {
       if (cfg.publisherSyncFrequency > 0) {
         LOG.info("Enable GBIF publisher syncs every {} hours", cfg.publisherSyncFrequency);
         futures.add(scheduler.scheduleAtFixedRate(
-          new PublisherSyncJob(cfg, client, sessionFactory, Users.GBIF_SYNC), 1, cfg.publisherSyncFrequency, TimeUnit.HOURS)
+          new PublisherSyncJob(registry, sessionFactory, Users.GBIF_SYNC), 1, cfg.publisherSyncFrequency, TimeUnit.HOURS)
         );
       }
 
       if (cfg.fullSyncFrequency > 0) {
         LOG.info("Schedule a full GBIF registry sync incl deletions every {} days", cfg.fullSyncFrequency);
         futures.add(scheduler.scheduleAtFixedRate(
-          new GbifSyncJob(cfg, client, ddao, sessionFactory, Users.GBIF_SYNC, false),
+          new GbifSyncJob(cfg, client, ddao, sessionFactory, registry, Users.GBIF_SYNC, false),
           0, cfg.fullSyncFrequency, TimeUnit.DAYS)
         );
       }
@@ -87,7 +94,7 @@ public class GbifSyncManager implements Managed {
         LOG.info("Enable incremental GBIF registry syncs every {} minutes", cfg.syncFrequency);
         // we delay the first run by 30 minutes as we do the full sync first
         futures.add(scheduler.scheduleAtFixedRate(
-          new GbifSyncJob(cfg, client, ddao, sessionFactory, Users.GBIF_SYNC, true),
+          new GbifSyncJob(cfg, client, ddao, sessionFactory, registry, Users.GBIF_SYNC, true),
           30, cfg.syncFrequency, TimeUnit.MINUTES)
         );
       }

--- a/core/src/main/java/life/catalogue/gbifsync/PublisherSyncJob.java
+++ b/core/src/main/java/life/catalogue/gbifsync/PublisherSyncJob.java
@@ -1,54 +1,36 @@
 package life.catalogue.gbifsync;
 
-import com.google.common.annotations.VisibleForTesting;
-
-import jakarta.ws.rs.WebApplicationException;
-
 import life.catalogue.api.model.Publisher;
-import life.catalogue.api.vocab.area.Country;
 import life.catalogue.concurrent.GlobalBlockingJob;
 import life.catalogue.concurrent.JobPriority;
-import life.catalogue.config.GbifConfig;
 import life.catalogue.db.mapper.DatasetMapper;
 import life.catalogue.db.mapper.PublisherMapper;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.WebApplicationException;
 
 public class PublisherSyncJob extends GlobalBlockingJob {
   private static final Logger LOG = LoggerFactory.getLogger(PublisherSyncJob.class);
 
-  private final WebTarget orgTarget;
   private final SqlSessionFactory sessionFactory;
-  private Set<UUID> keys;
+  private final GbifRegistryCache registry;
   private int created;
   private int updated;
-  private int deleted;
 
   /**
-   *  Syncs all publishers found in all datasets
+   *  Syncs all publishers found in all datasets, reusing the shared registry cache so organisations already
+   *  fetched by the dataset sync are not requested from the slow GBIF registry again.
    **/
-  public PublisherSyncJob(GbifConfig cfg, Client client, SqlSessionFactory sessionFactory, int userKey) {
+  public PublisherSyncJob(GbifRegistryCache registry, SqlSessionFactory sessionFactory, int userKey) {
     super(userKey, JobPriority.HIGH);
     this.sessionFactory = sessionFactory;
-    this.keys = keys == null ? new HashSet<>() : keys;
-    this.orgTarget = client.target(UriBuilder
-      .fromUri(cfg.api)
-      .path("/organization")
-    );
+    this.registry = registry;
   }
 
   @Override
@@ -75,38 +57,12 @@ public class PublisherSyncJob extends GlobalBlockingJob {
     LOG.info("{} publisher added, {} updated", created, updated);
   }
 
-  @VisibleForTesting
-  Publisher getFromGBIF(UUID key) throws Exception {
+  private Publisher getFromGBIF(UUID key) {
     try {
-      return orgTarget.path(key.toString())
-        .request(MediaType.APPLICATION_JSON_TYPE)
-        .get(GPublisher.class);
+      return registry.publisherEntity(key);
     } catch (WebApplicationException e) {
       LOG.warn("Publisher {} not found in GBIF", key, e);
       return null;
-    }
-  }
-
-  public static class GPublisher extends Publisher {
-    public void setHomepage(List<String> homepages) {
-      if (homepages != null && !homepages.isEmpty()) {
-        super.setHomepage(StringUtils.trimToNull(homepages.get(0)));
-      } else {
-        super.setHomepage(null);
-      }
-    }
-
-    public void setCountry(String country) {
-      if (StringUtils.isBlank(country)) {
-        super.setCountry(null);
-      } else {
-        var opt = Country.fromIsoCode(country);
-        if (opt.isPresent()) {
-          super.setCountry(opt.get().getName());
-        } else {
-          super.setCountry(country);
-        }
-      }
     }
   }
 }

--- a/core/src/test/java/life/catalogue/gbifsync/DatasetPagerTest.java
+++ b/core/src/test/java/life/catalogue/gbifsync/DatasetPagerTest.java
@@ -6,6 +6,7 @@ import life.catalogue.api.jackson.ApiModule;
 import life.catalogue.config.GbifConfig;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
@@ -93,6 +95,33 @@ public class DatasetPagerTest {
     DatasetPager.GDataset d = new DatasetPager.GDataset();
     d.key = key;
     return d;
+  }
+
+  /**
+   * The retry backoff must stay in the seconds range (and never grow into minutes like the old tries*tries minutes),
+   * so a single slow GBIF page can never stall the whole sync.
+   */
+  @Test
+  public void backoffSeconds() {
+    for (int tries = 1; tries <= 6; tries++) {
+      long secs = DatasetPager.backoffSeconds(tries);
+      assertTrue("backoff must be positive", secs >= 2);
+      // capped at 60s plus up to 50% jitter - never minutes-long like the old tries*tries minutes
+      assertTrue("backoff " + secs + "s for try " + tries + " must stay within seconds", secs <= 90);
+    }
+  }
+
+  @Test
+  public void parseGbifDateTime() {
+    // GBIF returns ISO-8601 with offset; we store as UTC LocalDateTime
+    assertEquals(LocalDateTime.of(2026, 6, 9, 20, 4, 21, 795_000_000),
+      DatasetPager.parseGbifDateTime("2026-06-09T20:04:21.795+00:00"));
+    // a +02:00 offset is normalised to UTC
+    assertEquals(LocalDateTime.of(2026, 6, 9, 18, 4, 21),
+      DatasetPager.parseGbifDateTime("2026-06-09T20:04:21+02:00"));
+    assertNull(DatasetPager.parseGbifDateTime(null));
+    assertNull(DatasetPager.parseGbifDateTime("  "));
+    assertNull(DatasetPager.parseGbifDateTime("not a date"));
   }
 
 }

--- a/core/src/test/java/life/catalogue/gbifsync/GbifSyncJobTest.java
+++ b/core/src/test/java/life/catalogue/gbifsync/GbifSyncJobTest.java
@@ -1,0 +1,42 @@
+package life.catalogue.gbifsync;
+
+import life.catalogue.api.model.DatasetGBIF;
+
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GbifSyncJobTest {
+
+  private static DatasetPager.GbifDataset gbif(LocalDateTime modified) {
+    DatasetPager.GbifDataset d = new DatasetPager.GbifDataset();
+    d.modified = modified;
+    return d;
+  }
+
+  private static DatasetGBIF existing(LocalDateTime stored) {
+    DatasetGBIF d = new DatasetGBIF();
+    d.setGbifModified(stored);
+    return d;
+  }
+
+  /**
+   * The delta gate decides whether a GBIF dataset can be skipped without hitting the registry or the DB.
+   */
+  @Test
+  public void isUnchanged() {
+    LocalDateTime t = LocalDateTime.of(2026, 6, 9, 20, 0);
+    // same timestamp -> unchanged, can skip
+    assertTrue(GbifSyncJob.isUnchanged(gbif(t), existing(t)));
+    // GBIF older than what we stored -> unchanged
+    assertTrue(GbifSyncJob.isUnchanged(gbif(t.minusSeconds(1)), existing(t)));
+    // GBIF newer than stored -> changed, must process
+    assertFalse(GbifSyncJob.isUnchanged(gbif(t.plusSeconds(1)), existing(t)));
+    // unknown timestamps -> treat as changed so the dataset is processed once and its watermark recorded
+    assertFalse(GbifSyncJob.isUnchanged(gbif(null), existing(t)));
+    assertFalse(GbifSyncJob.isUnchanged(gbif(t), existing(null)));
+  }
+}

--- a/core/src/test/java/life/catalogue/gbifsync/GbifSyncTest.java
+++ b/core/src/test/java/life/catalogue/gbifsync/GbifSyncTest.java
@@ -74,7 +74,7 @@ public class GbifSyncTest {
 
   @Test
   public void syncSingle() {
-    GbifSyncJob job = new GbifSyncJob(cfg, client, ddao, SqlSessionFactoryRule.getSqlSessionFactory(), Users.GBIF_SYNC, Set.of(UUID.fromString("30f55c63-a829-4cb2-9676-3b1b6f981567")), false);
+    GbifSyncJob job = new GbifSyncJob(cfg, client, ddao, SqlSessionFactoryRule.getSqlSessionFactory(), new GbifRegistryCache(client, cfg), Users.GBIF_SYNC, Set.of(UUID.fromString("30f55c63-a829-4cb2-9676-3b1b6f981567")), false);
     job.run();
     Assert.assertEquals(JobStatus.FINISHED, job.getStatus());
   }

--- a/core/src/test/java/life/catalogue/gbifsync/PublisherSyncJobTest.java
+++ b/core/src/test/java/life/catalogue/gbifsync/PublisherSyncJobTest.java
@@ -34,8 +34,8 @@ public class PublisherSyncJobTest {
     cfg.register(new LoggingFeature(Logger.getLogger(getClass().getName()), Level.ALL, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024));
 
     var cl = ClientBuilder.newClient(cfg);
-    var job = new PublisherSyncJob(gcfg, cl, null, 1);
-    var plazi = job.getFromGBIF(Publishers.PLAZI);
+    var registry = new GbifRegistryCache(cl, gcfg);
+    var plazi = registry.publisherEntity(Publishers.PLAZI);
     assertNotNull(plazi);
     assertEquals(Publishers.PLAZI, plazi.getKey());
     assertEquals("Plazi.org taxonomic treatments database", plazi.getTitle());

--- a/dao/src/main/java/life/catalogue/config/GbifConfig.java
+++ b/dao/src/main/java/life/catalogue/config/GbifConfig.java
@@ -52,6 +52,13 @@ public class GbifConfig {
   public int publisherSyncFrequency = 24;
 
   /**
+   * Hours to cache GBIF registry publisher &amp; host organisations in memory, shared across sync runs.
+   * Avoids re-fetching the same slow organisation endpoints on every dataset and publisher sync.
+   * If zero or negative a default of 12h is used.
+   */
+  public int registryCacheHours = 12;
+
+  /**
    * GBIF publisher keys for journals and other publishers who exclusively publish article based datasets, e.g. Plazi & Pensoft.
    */
   @NotNull

--- a/dao/src/main/java/life/catalogue/db/mapper/DatasetMapper.java
+++ b/dao/src/main/java/life/catalogue/db/mapper/DatasetMapper.java
@@ -429,6 +429,12 @@ public interface DatasetMapper extends CRUD<Integer, Dataset>, GlobalPageable<Da
   List<DatasetGBIF> listGBIF();
 
   /**
+   * Updates only the GBIF registry modified timestamp we last synced for a dataset.
+   * Used by the GBIF sync to track per-dataset deltas without touching any other dataset metadata.
+   */
+  int updateGbifModified(@Param("key") int key, @Param("modified") LocalDateTime modified);
+
+  /**
    * @return the last import attempt or null if never attempted
    */
   Integer lastImportAttempt(@Param("key") int datasetKey);

--- a/dao/src/main/resources/life/catalogue/db/dbschema.md
+++ b/dao/src/main/resources/life/catalogue/db/dbschema.md
@@ -11,6 +11,13 @@ and done it manually. So we can as well log changes here.
 
 ### PROD changes
 
+#### 2026-06-10 GBIF sync delta tracking
+Track the GBIF registry `modified` timestamp we last synced per dataset, so the incremental sync can
+skip datasets that have not changed since the previous run and we can poll the registry far more often.
+```
+ALTER TABLE dataset ADD COLUMN gbif_modified TIMESTAMP WITHOUT TIME ZONE;
+```
+
 #### 2026-06-04 name-parser 3.16 code-specific series ranks
 name-parser 3.16 replaced the ambiguous generic series ranks (`SUPERSERIES`, `SERIES`, `SUBSERIES`)
 with code-specific ones. The generic ranks sat in the botanical block, so we rename them in place to

--- a/dao/src/main/resources/life/catalogue/db/dbschema.sql
+++ b/dao/src/main/resources/life/catalogue/db/dbschema.sql
@@ -864,6 +864,7 @@ CREATE TABLE dataset (
   origin DATASETORIGIN NOT NULL,
   gbif_key UUID UNIQUE,
   gbif_publisher_key UUID,
+  gbif_modified TIMESTAMP WITHOUT TIME ZONE,
 
   identifier TEXT[],
   title TEXT NOT NULL,
@@ -973,6 +974,7 @@ CREATE INDEX ON dataset_citation (dataset_key);
 
 CREATE TABLE dataset_archive (LIKE dataset);
 ALTER TABLE dataset_archive
+  DROP COLUMN gbif_modified,
   DROP COLUMN deleted,
   DROP COLUMN doc,
   DROP COLUMN acl_editor,

--- a/dao/src/main/resources/life/catalogue/db/mapper/DatasetMapper.xml
+++ b/dao/src/main/resources/life/catalogue/db/mapper/DatasetMapper.xml
@@ -660,10 +660,14 @@
   </select>
 
   <select id="listGBIF" resultMap="datasetGBIFResultMap">
-    SELECT <include refid="SELECT_SIMPLE"/>, d.gbif_key
+    SELECT <include refid="SELECT_SIMPLE"/>, d.gbif_key, d.gbif_modified
     FROM dataset d
     WHERE d.deleted IS NULL AND d.gbif_key IS NOT NULL
   </select>
+
+  <update id="updateGbifModified">
+    UPDATE dataset SET gbif_modified = #{modified} WHERE key = #{key}
+  </update>
 
   <!--  makes sure to add creator to editors if its not a bot with key<100 -->
   <insert id="create" parameterType="Dataset" useGeneratedKeys="true" keyProperty="key">

--- a/webservice/src/main/java/life/catalogue/resources/AdminResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/AdminResource.java
@@ -200,7 +200,7 @@ public class AdminResource {
   @Path("/gbif-sync")
   @Consumes(MediaType.APPLICATION_JSON)
   public BackgroundJob syncGBIF(List<UUID> keys, @Auth User user) {
-    GbifSyncJob job = new GbifSyncJob(cfg.gbif, gbifSync.getClient(), ddao, factory, user.getKey(), Set.copyOf(keys), false);
+    GbifSyncJob job = new GbifSyncJob(cfg.gbif, gbifSync.getClient(), ddao, factory, gbifSync.getRegistryCache(), user.getKey(), Set.copyOf(keys), false);
     return runJob(job);
   }
 
@@ -210,7 +210,7 @@ public class AdminResource {
   public BackgroundJob syncGBIFText(InputStream keysAsText, @Auth User user) {
     try (var lr = new LineReader(keysAsText)) {
       var keys = IterUtils.setOf(lr, UUID::fromString);
-      GbifSyncJob job = new GbifSyncJob(cfg.gbif, gbifSync.getClient(), ddao, factory, user.getKey(), keys, false);
+      GbifSyncJob job = new GbifSyncJob(cfg.gbif, gbifSync.getClient(), ddao, factory, gbifSync.getRegistryCache(), user.getKey(), keys, false);
       return runJob(job);
     }
   }
@@ -218,7 +218,7 @@ public class AdminResource {
   @POST
   @Path("/publisher-sync")
   public BackgroundJob publisherSync(@Auth User user) {
-    PublisherSyncJob job = new PublisherSyncJob(cfg.gbif, gbifSync.getClient(), factory, user.getKey());
+    PublisherSyncJob job = new PublisherSyncJob(gbifSync.getRegistryCache(), factory, user.getKey());
     return runJob(job);
   }
 


### PR DESCRIPTION
## Why

The 15-min `GbifSyncJob` was slow and hammered the GBIF registry (which is itself slow and often times out):

- **Cold caches every run** — `DatasetPager` was recreated each run, so publisher/host organisation lookups (`/organization`, `/installation`) were re-fetched from the registry on every run; the daily full sync re-fetched thousands.
- **No intra-day delta detection** — each run asked `modified=<today>` and re-converted + re-checked *every dataset modified anytime today* across all ~96 daily runs.
- **Pathological retry backoff** — `tries*tries` **minutes** (up to ~8.5h), so a single slow page stalled the whole job.

Goal: only touch true deltas, so we can poll the registry every **1–5 min** for low GBIF→CLB latency at a fraction of the load.

## What

- **`GbifRegistryCache`** — shared, long-lived (TTL, `registryCacheHours`, default 12h) cache of publisher & host organisations, reused across all sync runs and by the publisher sync. The raw org is cached once and derived into both a publisher `Agent` and a `Publisher` entity, so each org is fetched at most once per TTL window regardless of which sync needs it.
- **Delta-skip** via a new `dataset.gbif_modified` column — datasets whose GBIF `modified` timestamp hasn't advanced since the last sync are skipped *before* any registry lookup or DB read. The watermark is recorded for create/update/locked/no-op alike.
- **Bulk preload** — one `listGBIF()` map per run replaces the per-dataset `getWithSettings` lookups; full settings load only for new/changed datasets.
- **Lazy convert** — `DatasetPager.convert()` maps only data already in the page; the slow publisher/host/contact resolution moved to `resolveAgents()`, called only for new/changed datasets.
- **Bounded backoff** — retry now uses seconds (2→60 + jitter, 6 tries) instead of `tries*tries` minutes.

## Schema

`gbif_modified TIMESTAMP` added to the `dataset` table only (dropped from the archive/source/patch template tables). No Liquibase — DDL logged in `dbschema.md` and added to `dbschema.sql`. Prod migration:

```sql
ALTER TABLE dataset ADD COLUMN gbif_modified TIMESTAMP WITHOUT TIME ZONE;
```

## Tests

New pure-unit tests for the bounded backoff, GBIF timestamp parsing, and the delta-skip predicate (`DatasetPagerTest`, `GbifSyncJobTest`) — all green. The existing live-service tests (`GbifSyncTest`, `DatasetPagerTest#datasetPager`, `PublisherSyncJobTest`) were updated to the new API but remain `@Disabled` (need live GBIF or mocking).

## Deploy follow-up

- Apply the `ALTER TABLE` above to prod.
- Once deployed, drop `gbif.syncFrequency` to **1–5 min** (deploy config) — runs are now cheap enough.
- **One-time cost:** the first full sync after deploy re-examines every existing dataset once (their `gbif_modified` is null) to populate watermarks; steady-state is cheap afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)