### PR TITLE
Interpret WoRMS Invasiveness term as degree of establishment

### DIFF
--- a/importer/src/main/java/life/catalogue/importer/InterpreterBase.java
+++ b/importer/src/main/java/life/catalogue/importer/InterpreterBase.java
@@ -401,11 +401,16 @@ public class InterpreterBase {
         switch (status.get()) {
           case NATIVE:
             d.setEstablishmentMeans(EstablishmentMeans.NATIVE);
-            d.setDegreeOfEstablishment(DegreeOfEstablishment.NATIVE);
+            // an explicitly given degree of establishment, e.g. the WoRMS Invasiveness, takes precedence over the status guess
+            if (d.getDegreeOfEstablishment() == null) {
+              d.setDegreeOfEstablishment(DegreeOfEstablishment.NATIVE);
+            }
             break;
           case DOMESTICATED:
             d.setEstablishmentMeans(EstablishmentMeans.INTRODUCED);
-            d.setDegreeOfEstablishment(DegreeOfEstablishment.CULTIVATED);
+            if (d.getDegreeOfEstablishment() == null) {
+              d.setDegreeOfEstablishment(DegreeOfEstablishment.CULTIVATED);
+            }
             break;
           case ALIEN:
             d.setEstablishmentMeans(EstablishmentMeans.INTRODUCED);

--- a/importer/src/main/java/life/catalogue/importer/dwca/DwcInterpreter.java
+++ b/importer/src/main/java/life/catalogue/importer/dwca/DwcInterpreter.java
@@ -40,6 +40,8 @@ public class DwcInterpreter extends InterpreterBase {
     ALT_ID_TERMS.put(WfoTerm.ipniID, Identifier.Scope.IPNI);
   }
   private static final Set<String> IS_TRUE = Set.of("isinvasive", "invasive", "ishybrid", "hybrid");
+  // WoRMS uses its custom Invasiveness term instead of dwc:degreeOfEstablishment, https://github.com/CatalogueOfLife/backend/issues/1511
+  private static final Term WORMS_INVASIVENESS = UnknownTerm.build("http://www.marinespecies.org/traits/Invasiveness", "Invasiveness", false);
 
   private final Term idTerm;
   private final Map<String, String> dwcaID2taxonID = new HashMap<>();
@@ -216,12 +218,14 @@ public class DwcInterpreter extends InterpreterBase {
   }
   
   List<Distribution> interpretDistribution(VerbatimRecord rec) {
+    // WoRMS uses its custom Invasiveness term instead of dwc:degreeOfEstablishment, https://github.com/CatalogueOfLife/backend/issues/1511
+    final Term tDegree = rec.hasTerm(DwcTerm.degreeOfEstablishment) ? DwcTerm.degreeOfEstablishment : WORMS_INVASIVENESS;
     // try to figure out an area
     if (rec.hasTerm(DwcTerm.locationID)) {
       return createDistribution(null, rec.getRaw(DwcTerm.locationID), rec.get(DwcTerm.locality), rec,
           DwcTerm.occurrenceStatus,
           DwcTerm.establishmentMeans,
-          DwcTerm.degreeOfEstablishment,
+          tDegree,
           DwcTerm.pathway,
           IucnTerm.threatStatus,
           DwcTerm.eventDate,
@@ -229,12 +233,12 @@ public class DwcInterpreter extends InterpreterBase {
           DwcTerm.lifeStage,
           DwcTerm.occurrenceRemarks,
           this::setReference);
-      
+
     } else if (rec.hasTerm(DwcTerm.countryCode) && !rec.hasTerm(DwcTerm.locality)) {
       return createDistribution(Gazetteer.ISO, rec.get(DwcTerm.countryCode), rec.get(DwcTerm.country), rec,
           DwcTerm.occurrenceStatus,
           DwcTerm.establishmentMeans,
-          DwcTerm.degreeOfEstablishment,
+          tDegree,
           DwcTerm.pathway,
           IucnTerm.threatStatus,
           DwcTerm.eventDate,
@@ -247,7 +251,7 @@ public class DwcInterpreter extends InterpreterBase {
       return createDistribution(Gazetteer.TEXT, null, rec.getFirst(DwcTerm.locality, DwcTerm.country), rec,
           DwcTerm.occurrenceStatus,
           DwcTerm.establishmentMeans,
-          DwcTerm.degreeOfEstablishment,
+          tDegree,
           DwcTerm.pathway,
           IucnTerm.threatStatus,
           DwcTerm.eventDate,

--- a/importer/src/test/java/life/catalogue/importer/NormalizerDwcaIT.java
+++ b/importer/src/test/java/life/catalogue/importer/NormalizerDwcaIT.java
@@ -595,6 +595,41 @@ public class NormalizerDwcaIT extends NormalizerITBase {
     assertNotNull(v);
   }
 
+  /**
+   * WoRMS uses its custom Invasiveness term instead of dwc:degreeOfEstablishment.
+   * https://github.com/CatalogueOfLife/backend/issues/1511
+   */
+  @Test
+  public void wormsInvasiveness() throws Exception {
+    normalize(57);
+
+    var data = store.nameUsage("1");
+    var u = data.ud;
+    assertEquals(3, u.distributions.size());
+    for (var d : u.distributions) {
+      assertEquals(Gazetteer.TEXT, d.getArea().getGazetteer());
+      switch (d.getArea().getName()) {
+        case "Mediterranean Sea":
+          // WoRMS Invasiveness "Invasive" interpreted as degree of establishment
+          assertEquals(DegreeOfEstablishment.INVASIVE, d.getDegreeOfEstablishment());
+          assertEquals(EstablishmentMeans.INTRODUCED, d.getEstablishmentMeans());
+          break;
+        case "North Sea":
+          // "Uncertain" is a WoRMS Invasiveness value without a TDWG degree of establishment, accepted as empty
+          assertNull(d.getDegreeOfEstablishment());
+          assertEquals(EstablishmentMeans.NATIVE, d.getEstablishmentMeans());
+          break;
+        case "Baltic Sea":
+          // no establishmentMeans given: the explicit Invasiveness degree must survive the occurrenceStatus guess
+          assertEquals(DegreeOfEstablishment.INVASIVE, d.getDegreeOfEstablishment());
+          assertEquals(EstablishmentMeans.NATIVE, d.getEstablishmentMeans());
+          break;
+        default:
+          fail("unexpected area " + d.getArea().getName());
+      }
+    }
+  }
+
   @Test
   @Disabled @Ignore
   public void testExternal() throws Exception {

--- a/importer/src/test/resources/dwca/57/distribution.txt
+++ b/importer/src/test/resources/dwca/57/distribution.txt
@@ -1,0 +1,4 @@
+taxonID	locality	occurrenceStatus	establishmentMeans	Invasiveness
+1	Mediterranean Sea	present	Alien	Invasive
+1	North Sea	present	Native	Uncertain
+1	Baltic Sea	present		Invasive

--- a/importer/src/test/resources/dwca/57/meta.xml
+++ b/importer/src/test/resources/dwca/57/meta.xml
@@ -1,0 +1,22 @@
+<archive xmlns="http://rs.tdwg.org/dwc/text/">
+  <core encoding="UTF-8" fieldsTerminatedBy="\t" linesTerminatedBy="\n" fieldsEnclosedBy="" ignoreHeaderLines="1" rowType="http://rs.tdwg.org/dwc/terms/Taxon">
+    <files>
+      <location>taxon.txt</location>
+    </files>
+    <id index="0" />
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/taxonID"/>
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <field index="2" term="http://rs.tdwg.org/dwc/terms/taxonRank"/>
+  </core>
+  <extension encoding="UTF-8" fieldsTerminatedBy="\t" linesTerminatedBy="\n" fieldsEnclosedBy="" ignoreHeaderLines="1" rowType="http://rs.gbif.org/terms/1.0/Distribution">
+    <files>
+      <location>distribution.txt</location>
+    </files>
+    <coreid index="0" />
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/locality"/>
+    <field index="2" term="http://rs.tdwg.org/dwc/terms/occurrenceStatus"/>
+    <field index="3" term="http://rs.tdwg.org/dwc/terms/establishmentMeans"/>
+    <!-- WoRMS uses its custom Invasiveness term for the degree of establishment, see #1511 -->
+    <field index="4" term="http://www.marinespecies.org/traits/Invasiveness"/>
+  </extension>
+</archive>

--- a/importer/src/test/resources/dwca/57/taxon.txt
+++ b/importer/src/test/resources/dwca/57/taxon.txt
@@ -1,0 +1,2 @@
+taxonID	scientificName	taxonRank
+1	Carcinus maenas (Linnaeus, 1758)	species

--- a/parser/src/main/java/life/catalogue/parser/DegreeOfEstablishmentParser.java
+++ b/parser/src/main/java/life/catalogue/parser/DegreeOfEstablishmentParser.java
@@ -2,15 +2,40 @@ package life.catalogue.parser;
 
 
 import life.catalogue.api.vocab.DegreeOfEstablishment;
+import life.catalogue.common.text.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
- * Parses TaxonomicStatus
+ * Parses the TDWG degree of establishment vocabulary https://dwc.tdwg.org/doe/
  */
 public class DegreeOfEstablishmentParser extends EnumParser<DegreeOfEstablishment> {
   public static final DegreeOfEstablishmentParser PARSER = new DegreeOfEstablishmentParser();
 
+  // WoRMS uses its own Invasiveness vocabulary (http://www.marinespecies.org/traits/Invasiveness) for the
+  // degree of establishment. Apart from "Invasive" none of its values correspond to a TDWG degree of
+  // establishment, so we accept them silently as empty instead of flagging them as invalid.
+  // "NA"/"N/A" are common not-applicable placeholders, e.g. in GRIIS archives.
+  // https://github.com/CatalogueOfLife/backend/issues/1511
+  private static final Set<String> NON_DEGREES = List.of(
+      "not invasive", "of concern", "management recorded",
+      "uncertain", "invasiveness uncertain", "invasiveness not specified", "not specified",
+      "na")
+    .stream()
+    .map(String::toUpperCase)
+    .map(StringUtils::digitOrAsciiLetters)
+    .map(x -> x.replaceAll(" +", "")) // the map parser normalise method does it
+    .collect(Collectors.toSet());
+
   public DegreeOfEstablishmentParser() {
     super("degreeofestablishment.csv", DegreeOfEstablishment.class);
+  }
+
+  @Override
+  protected boolean isEmpty(String normalisedValue) {
+    return NON_DEGREES.contains(normalisedValue);
   }
 
 }

--- a/parser/src/test/java/life/catalogue/parser/DegreeOfEstablishmentParserTest.java
+++ b/parser/src/test/java/life/catalogue/parser/DegreeOfEstablishmentParserTest.java
@@ -1,6 +1,6 @@
 package life.catalogue.parser;
 
-import life.catalogue.api.vocab.EstablishmentMeans;
+import life.catalogue.api.vocab.DegreeOfEstablishment;
 
 import java.util.List;
 
@@ -8,15 +8,36 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 
-public class DegreeOfEstablishmentParserTest extends ParserTestBase<EstablishmentMeans> {
+public class DegreeOfEstablishmentParserTest extends ParserTestBase<DegreeOfEstablishment> {
 
   public DegreeOfEstablishmentParserTest() {
-    super(EstablishmentMeansParser.PARSER);
+    super(DegreeOfEstablishmentParser.PARSER);
   }
 
   @Test
   public void parse() throws Exception {
-    assertParse(EstablishmentMeans.NATIVE, "native");
+    assertParse(DegreeOfEstablishment.NATIVE, "native");
+    assertParse(DegreeOfEstablishment.INVASIVE, "invasive");
+    assertParse(DegreeOfEstablishment.INVASIVE, "Invasive"); // WoRMS Invasiveness vocabulary
+    assertParse(DegreeOfEstablishment.WIDESPREAD_INVASIVE, "widespread invasive");
+  }
+
+  /**
+   * WoRMS uses its Invasiveness vocabulary for the degree of establishment. Apart from "Invasive" none of its
+   * values map to a TDWG degree of establishment, so they must be accepted silently as empty rather than invalid.
+   * "NA"/"N/A" are common not-applicable placeholders, e.g. in GRIIS archives.
+   * https://github.com/CatalogueOfLife/backend/issues/1511
+   */
+  @Test
+  public void emptyNonDegrees() throws Exception {
+    assertEmpty("Not invasive");
+    assertEmpty("Of concern");
+    assertEmpty("Management recorded");
+    assertEmpty("Uncertain");
+    assertEmpty("Invasiveness Uncertain");
+    assertEmpty("Invasiveness Not specified");
+    assertEmpty("NA");
+    assertEmpty("N/A");
   }
 
   @Override


### PR DESCRIPTION
Fixes #1511

## Problem
WoRMS's DwC-A maps its degree-of-establishment column to the custom term `http://www.marinespecies.org/traits/Invasiveness` instead of `dwc:degreeOfEstablishment`, so the importer never interpreted it. The few records carrying values also produced `distribution invalid` issues.

## Changes
- **`DwcInterpreter`** — reads `degreeOfEstablishment` from the WoRMS `Invasiveness` term as a fallback to `dwc:degreeOfEstablishment`. Uses an `UnknownTerm` constant; equality is by URI, so it matches the term the DwC-A reader stores.
- **`DegreeOfEstablishmentParser`** — `"Invasive"` already maps to `INVASIVE`. The other WoRMS Invasiveness values (`Not invasive`, `Of concern`, `Management recorded`, `Uncertain`, `Invasiveness Not specified`…) and the common `NA`/`N/A` placeholders don't correspond to any TDWG degree, so they're now accepted silently as empty (following the existing `TypeStatusParser.NON_TYPES`/`isEmpty` pattern) rather than flagged invalid.
- **`InterpreterBase`** — the `occurrenceStatus`-based fallback (`present` → `NATIVE`) no longer **overwrites** an already-parsed degree of establishment; it only fills it when unset. Necessary because many WoRMS records carry the Invasiveness term but no `establishmentMeans`.

## Tests
- Rewrote `DegreeOfEstablishmentParserTest` (it duplicated `EstablishmentMeansParserTest` and actually tested the wrong parser) to cover the real degree parser, including the WoRMS empties.
- Added `NormalizerDwcaIT.wormsInvasiveness` with a new `dwca/57` fixture covering: `Invasive`→`INVASIVE`, `Uncertain`→empty, and the no-`establishmentMeans` override-precedence case.

All 158 parser tests and 24 `NormalizerDwcaIT` tests pass.

## Out of scope (noted)
The same WoRMS distribution view shows `establishmentMeans` values `Native - Non-endemic` and `Origin unknown` that also don't parse (→ `distribution invalid`). That's a separate `establishmentmeans.csv` gap, not the Invasiveness term this issue is about — can be a quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)