### PR TITLE
Breakdown: optional countRank parameter (#1584)

### DIFF
--- a/dao/src/main/java/life/catalogue/dao/TaxonDao.java
+++ b/dao/src/main/java/life/catalogue/dao/TaxonDao.java
@@ -825,16 +825,19 @@ public class TaxonDao extends NameUsageBaseDao<Taxon, TaxonMapper> implements Ta
     return childrenBreakdownCollector(datasetKey, id, 1);
   }
   public JsonTreeCollector childrenBreakdownCollector(int datasetKey, String id, int levels) {
-    var wrapper = childrenBreakdown(JsonTreeCollector.class, datasetKey, id, levels, new StringWriter());
+    var wrapper = childrenBreakdown(JsonTreeCollector.class, datasetKey, id, levels, Rank.SPECIES, new StringWriter());
     wrapper.printer.setTaxon(wrapper.taxon);
     return wrapper.printer;
   }
 
   public JsonTreePrinter childrenBreakdownPrinter(int datasetKey, String id, Writer writer) {
-    return childrenBreakdownPrinter(datasetKey, id, 1, writer);
+    return childrenBreakdownPrinter(datasetKey, id, 1, Rank.SPECIES, writer);
   }
   public JsonTreePrinter childrenBreakdownPrinter(int datasetKey, String id, int level, Writer writer) {
-    return childrenBreakdown(JsonTreePrinter.class, datasetKey, id, level, writer).printer;
+    return childrenBreakdownPrinter(datasetKey, id, level, Rank.SPECIES, writer);
+  }
+  public JsonTreePrinter childrenBreakdownPrinter(int datasetKey, String id, int level, @Nullable Rank countRank, Writer writer) {
+    return childrenBreakdown(JsonTreePrinter.class, datasetKey, id, level, countRank, writer).printer;
   }
 
   private static class PrinterWrapper<T> {
@@ -851,9 +854,12 @@ public class TaxonDao extends NameUsageBaseDao<Taxon, TaxonMapper> implements Ta
    * @param level number of nesting levels for major Linnean ranks to return.
    *               Currently only 1 or 2 is supported, e.g. orders and families.
    */
-  private <T extends AbstractPrinter> PrinterWrapper<T> childrenBreakdown(Class<T> clazz, int datasetKey, String id, int level, Writer writer) {
+  private <T extends AbstractPrinter> PrinterWrapper<T> childrenBreakdown(Class<T> clazz, int datasetKey, String id, int level, @Nullable Rank countRank, Writer writer) {
     if (level != 1 && level != 2) {
       throw new IllegalArgumentException("Breakdown level has to be 1 or 2, not " + level);
+    }
+    if (countRank == null) {
+      countRank = Rank.SPECIES;
     }
     var key = DSID.of(datasetKey, id);
     var tax = getSimpleOr404(key);
@@ -890,7 +896,7 @@ public class TaxonDao extends NameUsageBaseDao<Taxon, TaxonMapper> implements Ta
       taxonCounter = metricsDao;
     }
 
-    return new PrinterWrapper<>(PrinterFactory.dataset(clazz, ttp, ranks, null, Rank.SPECIES, taxonCounter, factory, writer), tax);
+    return new PrinterWrapper<>(PrinterFactory.dataset(clazz, ttp, ranks, null, countRank, taxonCounter, factory, writer), tax);
   }
 
   /**

--- a/dao/src/test/java/life/catalogue/dao/TaxonDaoIT.java
+++ b/dao/src/test/java/life/catalogue/dao/TaxonDaoIT.java
@@ -377,6 +377,23 @@ public class TaxonDaoIT extends DaoTestBase {
     assertEquals(3, cnt);
   }
 
+  @Test
+  public void childrenBreakdownPrinterCountRank() throws IOException {
+    final int datasetKey = setupTestTreeDataset();
+    var writer = new StringWriter();
+    // count a non-default rank: each node reports how many orders it contains,
+    // emitted under a property named after that rank (groups without species
+    // can use this to fall back to e.g. genus counts).
+    var breakdown = tDao.childrenBreakdownPrinter(datasetKey, "t2", 2, Rank.ORDER, writer);
+    breakdown.print();
+    String json = writer.toString();
+    System.out.println(json);
+    // Insecta (t3) holds two orders: Coleoptera (t4) and Lepidoptera (t5)
+    assertTrue(json.contains("\"order\":2"));
+    // the count is emitted under the rank name, not the default "species"
+    assertFalse(json.contains("\"species\":"));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void updateIllegalParentChange(){
     MybatisTestUtils.populateDraftTree(session());

--- a/webservice/src/main/java/life/catalogue/resources/dataset/TaxonResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/dataset/TaxonResource.java
@@ -205,11 +205,15 @@ public class TaxonResource extends AbstractDatasetScopedResource<String, Taxon, 
                             @QueryParam("level") @DefaultValue("1")
                             @Parameter(description = "Depth of the breakdown tree. Only level 1 or 2 are supported.",
                                        schema = @Schema(type = "integer", allowableValues = {"1", "2"}, defaultValue = "1"))
-                            int level
+                            int level,
+                            @QueryParam("countRank") @DefaultValue("species")
+                            @Parameter(description = "Rank to count for each node, emitted as a property of that name. "
+                                                   + "Defaults to species; use e.g. genus for groups without species.")
+                            Rank countRank
   ) {
     StreamingOutput stream = os -> {
       try (Writer writer = UTF8IoUtils.writerFromStream(os);
-           JsonTreePrinter printer = dao.childrenBreakdownPrinter(datasetKey, id, level, writer)
+           JsonTreePrinter printer = dao.childrenBreakdownPrinter(datasetKey, id, level, countRank, writer)
       ) {
         printer.print();
         writer.flush();


### PR DESCRIPTION
## Summary

The taxon breakdown endpoint (`GET /dataset/{key}/taxon/{id}/breakdown`) always counted **species** per node. For genera-only groups — e.g. an order in IRMNG, where there are families and genera but no species — every node reported `species: 0` and the UI rendered an empty/hidden chart (#1584).

This adds an optional **`countRank`** query parameter (default `species`):

- Threaded from `TaxonResource.breakdown` through `TaxonDao.childrenBreakdownPrinter` → `childrenBreakdown` to `PrinterFactory.dataset` (which already accepted a `countRank`; it was just hard-coded to `Rank.SPECIES`).
- The per-node count is emitted under a property **named after the rank** (`JsonTreePrinter.countRankPropertyName` → lowercased rank name), so `?countRank=genus` yields `"genus": <n>` on each node.
- The metrics/ES `TaxonCounter`s already count any rank, so no counting logic changes were needed.

Existing callers and the no-param default behaviour are unchanged.

## Use case

The ChecklistBank UI taxon page sizes its breakdown pie by genus counts when a group has no species, labelling it accordingly. See the companion frontend change (CatalogueOfLife/checklistbank, "fall back to genus counts when no species").

## Testing

Added `TaxonDaoIT.childrenBreakdownPrinterCountRank`: breaks down a phylum counting `ORDER` and asserts the JSON carries `"order":2` (Insecta holds Coleoptera + Lepidoptera) and no `"species":`. Passes against a Testcontainers Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)