### PR TITLE
Add OpenRefine reconciliation service over the name matcher

### DIFF
--- a/OPENREFINE.md
+++ b/OPENREFINE.md
@@ -1,0 +1,132 @@
+# OpenRefine integration
+
+ChecklistBank exposes its **name matcher** and **name parsers** to
+[OpenRefine](https://openrefine.org) so that taxonomists can clean and enrich tabular name data
+without writing code.
+
+OpenRefine has two native extension points, and CoL maps onto both:
+
+| OpenRefine feature | CoL backend | What you get |
+|---|---|---|
+| **Reconciliation Service** | the name matcher (`UsageMatcher` / name index) | match a column of scientific names to CoL taxa, with scores and auto-match |
+| **Data Extension** | the matched taxon + its classification | pull authorship, rank, status, names-index id and higher ranks as new columns |
+| *Add column by fetching URLs* | the `/parser/*` REST endpoints | run any CoL parser (name, date, rank, country, …) over a column |
+
+## 1. Reconciling scientific names
+
+The reconciliation endpoint speaks the
+[Reconciliation Service API v0.2](https://reconciliation-api.github.io/specs/0.2/). It is driven by
+the name matcher (not autocomplete).
+
+| Endpoint | Purpose |
+|---|---|
+| `GET  /dataset/{key}/reconcile` | service manifest (what OpenRefine fetches first) |
+| `POST /dataset/{key}/reconcile` | batch reconciliation (`queries` form field or JSON body) |
+| `POST /dataset/{key}/reconcile/extend` | data extension |
+| `GET  /dataset/{key}/reconcile/extend/propose` | list of extension properties |
+| `GET  /dataset/{key}/reconcile/suggest/entity?prefix=` | taxon autocomplete |
+| `GET  /dataset/{key}/reconcile/suggest/property?prefix=` | extension-property autocomplete |
+| `…/reconcile` (no `/dataset/{key}`) | same service against the **COL backbone** default |
+
+CORS is enabled, so modern OpenRefine (3.x+) talks to it directly — no JSONP needed.
+
+### Add the service in OpenRefine
+
+1. On a column choose **Reconcile → Start reconciling… → Add Standard Service…**
+2. Paste the service URL:
+   - COL backbone: `https://api.checklistbank.org/reconcile`
+     (always the latest COL extended release, resolved per request)
+   - a specific dataset/release: `https://api.checklistbank.org/dataset/{key}/reconcile`
+
+   `{key}` accepts the usual dataset-key aliases, e.g. `3LXR` (latest COL extended release),
+   `3LR` (latest normal release), `COL2024`, or `gbif-<uuid>` — these are rewritten to the real
+   release key automatically.
+3. Reconcile the column. Exact hits (`matchType=EXACT`) auto-match; ambiguous/variant/canonical
+   hits are offered as a candidate list to pick from.
+
+### Improving matches with property hints
+
+When configuring reconciliation you can map other columns to **properties** that are passed to the
+matcher as hints. Recognised property ids:
+
+- `authorship`, `rank`, `code` (nomenclatural code)
+- any rank name used as a classification hint, e.g. `kingdom`, `family`, `genus`
+
+### Pulling extra columns (data extension)
+
+After reconciling, use **Edit column → Add columns from reconciled values…** and pick from:
+
+`scientificName`, `authorship`, `rank`, `status`, `nidx` (names-index id),
+`kingdom`, `phylum`, `class`, `order`, `family`, `genus`.
+
+### Quick smoke test with curl
+
+```bash
+# manifest
+curl 'https://api.checklistbank.org/reconcile'
+
+# reconcile a batch (form encoded, as OpenRefine sends it)
+curl -X POST 'https://api.checklistbank.org/reconcile' \
+  --data-urlencode 'queries={"q0":{"query":"Puma concolor"},"q1":{"query":"Aus bus","properties":[{"pid":"rank","v":"species"}]}}'
+
+# data extension
+curl -X POST 'https://api.checklistbank.org/reconcile/extend' \
+  -H 'Content-Type: application/json' \
+  -d '{"ids":["<usageId>"],"properties":[{"id":"authorship"},{"id":"family"}]}'
+```
+
+## 2. Running parsers over a column
+
+Every CoL parser is already a plain REST endpoint, so OpenRefine can call it per cell with
+**Edit column → Add column by fetching URLs…**.
+
+### Scientific names
+
+GREL URL expression (URL-encode the cell value):
+
+```
+"https://api.checklistbank.org/parser/name?q=" + escape(value, "url")
+```
+
+The response is a JSON array; parse the first element and extract atoms, e.g. in a follow-up
+**Add column based on this column** with GREL:
+
+```
+value.parseJson()[0].name.specificEpithet
+```
+
+Useful fields under `name`: `genus`, `specificEpithet`, `infraspecificEpithet`, `rank`,
+`combinationAuthorship`, `basionymAuthorship`; plus `issues` on the array element.
+
+### Typed value parsers
+
+`GET /parser/{type}?q={{value}}` returns `[{"original":…, "parsed":…, "parsable":…}]`. Available
+types include:
+
+`boolean`, `country`, `datasettype`, `date`, `distributionstatus`, `gazetteer`, `geotime`,
+`integer`, `language`, `license`, `lifezone`, `mediatype`, `nomcode`, `nomreltype`, `nomstatus`,
+`rank`, `referencetype`, `sex`, `taxonomicstatus`, `treatmentformat`, `typestatus`, `uri`.
+
+Example — normalise a free-text rank column:
+
+```
+"https://api.checklistbank.org/parser/rank?q=" + escape(value, "url")
+```
+
+then extract with `value.parseJson()[0].parsed`.
+
+`GET /parser` returns the full list of parser type names for discovery.
+
+> Tip: URL-fetching is one request per row. For large tables, set a throttle delay in the
+> *Add column by fetching URLs* dialog. For names specifically, prefer **reconciliation + data
+> extension** (one batched request per ~10 rows) over per-row parsing.
+
+## Implementation notes
+
+- Adapter code: `webservice/.../resources/matching/openrefine/`
+  (`OpenRefineModel`, `OpenRefineMapper`, `AbstractReconciliationResource`,
+  `ReconciliationResource`, `DefaultReconciliationResource`).
+- Reconciliation reuses the exact matcher path of `/dataset/{key}/match/nameusage`
+  (`AbstractMatchingJob.interpretAndMatch`); only the request/response shape differs.
+- Registered next to `NameUsageMatchingResource` in `WsServer`. Exposing it on the dedicated
+  read-only / matching server is a possible follow-up.

--- a/webservice/src/main/java/life/catalogue/WsServer.java
+++ b/webservice/src/main/java/life/catalogue/WsServer.java
@@ -75,6 +75,8 @@ import life.catalogue.release.PublisherChangeListener;
 import life.catalogue.resources.*;
 import life.catalogue.resources.dataset.*;
 import life.catalogue.resources.legacy.LegacyWebserviceResource;
+import life.catalogue.resources.matching.openrefine.DefaultReconciliationResource;
+import life.catalogue.resources.matching.openrefine.ReconciliationResource;
 import life.catalogue.resources.parser.NameParserAdminResource;
 import life.catalogue.resources.parser.ResolverResource;
 import life.catalogue.swagger.OpenApiFactory;
@@ -474,6 +476,9 @@ public class WsServer extends Application<WsServerConfig> {
     j.register(new DatasetBreakdownResource(tdao));
     j.register(new DatasetTaxDiffResource(executor, getSqlSessionFactory(), docker, cfg));
     j.register(new NameUsageMatchingResource(cfg.matching, executor, getSqlSessionFactory(), matcherFactory));
+    // OpenRefine reconciliation service over the name matcher (dataset-scoped + default COL backbone)
+    j.register(new ReconciliationResource(cfg.matching, suggestService, getSqlSessionFactory(), matcherFactory, cfg.getApiUri(), cfg.clbURI));
+    j.register(new DefaultReconciliationResource(cfg.matching, suggestService, getSqlSessionFactory(), matcherFactory, coljersey.getCache(), cfg.getApiUri(), cfg.clbURI));
     j.register(new LegacyWebserviceResource(cfg, env.metrics(), getSqlSessionFactory()));
     j.register(new SectorDiffResource(sDiff));
     j.register(new SectorResource(secdao, fmsDao, siDao, syncManager));

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/AbstractReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/AbstractReconciliationResource.java
@@ -1,0 +1,284 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+import life.catalogue.api.model.*;
+import life.catalogue.api.search.NameUsageSuggestRequest;
+import life.catalogue.api.search.NameUsageSuggestion;
+import life.catalogue.config.MatchingConfig;
+import life.catalogue.db.mapper.NameUsageMapper;
+import life.catalogue.db.mapper.TaxonMapper;
+import life.catalogue.es.suggest.NameUsageSuggestionService;
+import life.catalogue.interpreter.NameInterpreter;
+import life.catalogue.matching.AbstractMatchingJob;
+import life.catalogue.matching.MatchingUtils;
+import life.catalogue.matching.UsageMatch;
+import life.catalogue.matching.UsageMatcher;
+import life.catalogue.matching.UsageMatcherFactory;
+import life.catalogue.parser.NomCodeParser;
+import life.catalogue.parser.RankParser;
+import life.catalogue.parser.SafeParser;
+
+import org.gbif.nameparser.api.NomCode;
+import org.gbif.nameparser.api.Rank;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * OpenRefine Reconciliation Service API (spec 0.2) over the CoL name matcher.
+ * Exposes a service manifest, batch reconciliation (driven by the name matcher), data extension
+ * (taxon properties + classification), and entity/property suggest aids.
+ *
+ * Subclasses bind a concrete @Path and supply the {@link UsageMatcher} for a dataset, mirroring the
+ * {@link life.catalogue.resources.matching.AbstractNameUsageMatchingResource} pattern.
+ */
+@Produces(MediaType.APPLICATION_JSON)
+@SuppressWarnings("static-method")
+public abstract class AbstractReconciliationResource {
+  protected static final String DEFAULT_DATASET_KEY = "-99";
+  private static final int SUGGEST_LIMIT = 25;
+
+  protected final MatchingConfig cfg;
+  protected final NameUsageSuggestionService suggestService;
+  protected final SqlSessionFactory factory;
+  private final UsageMatcherFactory matcherFactory;
+  private final URI apiURI;
+  private final URI clbURI;
+  private final NameInterpreter interpreter = new NameInterpreter(new DatasetSettings(), true);
+
+  public AbstractReconciliationResource(MatchingConfig cfg, NameUsageSuggestionService suggestService,
+                                        SqlSessionFactory factory, UsageMatcherFactory matcherFactory, URI apiURI, URI clbURI) {
+    this.cfg = cfg;
+    this.suggestService = suggestService;
+    this.factory = factory;
+    this.matcherFactory = matcherFactory;
+    this.apiURI = apiURI;
+    this.clbURI = clbURI;
+  }
+
+  /** Returns the matcher to reconcile against for the given dataset. Override to plug in a fixed matcher. */
+  public UsageMatcher singleMatchMatcher(int datasetKey) {
+    try {
+      return matcherFactory.existingOrPostgres(datasetKey);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Resolves the path dataset key to the concrete key to reconcile against. By default this is the
+   * key itself (the alias filter has already rewritten things like {@code 3LXR}). The default
+   * endpoint overrides this to resolve the latest COL extended release at request time.
+   */
+  protected int resolveDatasetKey(int pathKey) {
+    return pathKey;
+  }
+
+  protected String apiBase() {
+    return apiURI == null ? "" : StringUtils.removeEnd(apiURI.toString(), "/");
+  }
+
+  /** Base URL of this service, used for the manifest's self and sub-service URLs. */
+  protected String reconcileBaseUrl(int datasetKey) {
+    return apiBase() + "/dataset/" + datasetKey + "/reconcile";
+  }
+
+  private String clbBase() {
+    return clbURI == null ? "https://www.checklistbank.org" : StringUtils.removeEnd(clbURI.toString(), "/");
+  }
+
+  // ---- Manifest + reconcile ----
+
+  @GET
+  public Object root(@PathParam("key") @DefaultValue(DEFAULT_DATASET_KEY) int datasetKey,
+                     @QueryParam("queries") String queries) {
+    int key = resolveDatasetKey(datasetKey);
+    if (queries == null) {
+      return OpenRefineMapper.manifest(key, reconcileBaseUrl(key), clbBase());
+    }
+    return reconcile(key, queries);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public Map<String, OpenRefineModel.Result> reconcileForm(@PathParam("key") @DefaultValue(DEFAULT_DATASET_KEY) int datasetKey,
+                                                           @FormParam("queries") String queries) {
+    return reconcile(resolveDatasetKey(datasetKey), queries);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Map<String, OpenRefineModel.Result> reconcileJson(@PathParam("key") @DefaultValue(DEFAULT_DATASET_KEY) int datasetKey,
+                                                           String body) {
+    // newer clients post {"queries": {...}}; older ones post the bare queries object
+    String queries = body;
+    try {
+      JsonNode node = ApiModule.MAPPER.readTree(body);
+      if (node != null && node.has("queries")) {
+        queries = node.get("queries").toString();
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON body: " + e.getMessage());
+    }
+    return reconcile(resolveDatasetKey(datasetKey), queries);
+  }
+
+  private Map<String, OpenRefineModel.Result> reconcile(int datasetKey, String queriesJson) {
+    Map<String, OpenRefineModel.Query> queries;
+    try {
+      queries = OpenRefineMapper.parseQueries(queriesJson, ApiModule.MAPPER);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid queries payload: " + e.getMessage());
+    }
+    Map<String, OpenRefineModel.Result> out = new LinkedHashMap<>();
+    try (var matcher = singleMatchMatcher(datasetKey)) {
+      MatchingUtils utils = new MatchingUtils(matcher.getNameIndex());
+      for (var e : queries.entrySet()) {
+        out.put(e.getKey(), reconcileSingle(e.getValue(), matcher, utils));
+      }
+    }
+    return out;
+  }
+
+  private OpenRefineModel.Result reconcileSingle(OpenRefineModel.Query q, UsageMatcher matcher, MatchingUtils utils) {
+    var sn = toSimpleName(q);
+    if (sn == null || StringUtils.isBlank(sn.getName())) {
+      return new OpenRefineModel.Result();
+    }
+    IssueContainer issues = new IssueContainer.Simple();
+    UsageMatch match = AbstractMatchingJob.interpretAndMatch(sn, sn.getClassification(), issues, true, interpreter, utils, matcher);
+    return OpenRefineMapper.toResult(match);
+  }
+
+  /** Builds a query name from the OpenRefine query string and its property hints. */
+  private SimpleNameClassified<SimpleNameCached> toSimpleName(OpenRefineModel.Query q) {
+    if (q == null || StringUtils.isBlank(q.query)) {
+      return null;
+    }
+    String authorship = null;
+    Rank rank = null;
+    NomCode code = null;
+    List<SimpleNameCached> classification = new ArrayList<>();
+    if (q.properties != null) {
+      for (var p : q.properties) {
+        String val = textValue(p.v);
+        if (p.pid == null || val == null) continue;
+        switch (p.pid) {
+          case "authorship":
+            authorship = val;
+            break;
+          case "code":
+            code = SafeParser.parse(NomCodeParser.PARSER, val).orNull();
+            break;
+          case "rank":
+            rank = SafeParser.parse(RankParser.PARSER, val).orNull();
+            break;
+          default:
+            Rank r = SafeParser.parse(RankParser.PARSER, p.pid).orNull();
+            if (r != null) {
+              classification.add(SimpleNameClassified.snc(null, r, null, null, val, null));
+            }
+        }
+      }
+    }
+    var sn = SimpleNameClassified.snc(null, rank, code, null, q.query, authorship);
+    if (!classification.isEmpty()) {
+      sn.setClassification(classification);
+    }
+    return sn;
+  }
+
+  private static String textValue(JsonNode v) {
+    if (v == null || v.isNull()) return null;
+    String s = v.isValueNode() ? v.asText() : v.toString();
+    return StringUtils.trimToNull(s);
+  }
+
+  // ---- Data extension ----
+
+  @POST
+  @Path("extend")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public OpenRefineModel.ExtendResponse extend(@PathParam("key") @DefaultValue(DEFAULT_DATASET_KEY) int datasetKey,
+                                               OpenRefineModel.ExtendQuery query) {
+    int datasetKeyResolved = resolveDatasetKey(datasetKey);
+    List<String> ids = query.ids == null ? List.of() : query.ids;
+    List<String> propertyIds = query.properties == null ? List.of()
+      : query.properties.stream().map(p -> p.id).collect(Collectors.toList());
+
+    Map<String, SimpleNameClassified<SimpleNameCached>> usages = new LinkedHashMap<>();
+    if (factory != null && !ids.isEmpty()) {
+      try (SqlSession session = factory.openSession()) {
+        var num = session.getMapper(NameUsageMapper.class);
+        var tm = session.getMapper(TaxonMapper.class);
+        for (String id : ids) {
+          DSID<String> key = DSID.of(datasetKeyResolved, id);
+          SimpleNameCached u = num.getSimpleCached(key);
+          if (u != null) {
+            SimpleNameClassified<SimpleNameCached> snc = new SimpleNameClassified<>(u);
+            List<SimpleName> cl = tm.classificationSimple(key);
+            if (cl != null) {
+              snc.setClassification(cl.stream().map(SimpleNameCached::new).collect(Collectors.toList()));
+            }
+            usages.put(id, snc);
+          }
+        }
+      }
+    }
+    return OpenRefineMapper.buildExtendResponse(ids, propertyIds, usages);
+  }
+
+  @GET
+  @Path("extend/propose")
+  public OpenRefineModel.ProposeResponse proposeProperties() {
+    return new OpenRefineModel.ProposeResponse(OpenRefineMapper.EXTENSION_PROPERTIES);
+  }
+
+  // ---- Suggest ----
+
+  @GET
+  @Path("suggest/entity")
+  public OpenRefineModel.SuggestResponse suggestEntity(@PathParam("key") @DefaultValue(DEFAULT_DATASET_KEY) int datasetKey,
+                                                       @QueryParam("prefix") String prefix) {
+    if (StringUtils.isBlank(prefix)) {
+      return new OpenRefineModel.SuggestResponse();
+    }
+    var req = new NameUsageSuggestRequest();
+    req.setQ(prefix);
+    req.setLimit(SUGGEST_LIMIT);
+    req.setDatasetFilter(resolveDatasetKey(datasetKey));
+    List<NameUsageSuggestion> suggestions = suggestService.suggest(req);
+    return OpenRefineMapper.toSuggestResponse(suggestions);
+  }
+
+  @GET
+  @Path("suggest/property")
+  public OpenRefineModel.SuggestResponse suggestProperty(@QueryParam("prefix") String prefix) {
+    var resp = new OpenRefineModel.SuggestResponse();
+    String p = prefix == null ? "" : prefix.toLowerCase();
+    for (var prop : OpenRefineMapper.EXTENSION_PROPERTIES) {
+      if (p.isEmpty() || prop.id.toLowerCase().startsWith(p) || prop.name.toLowerCase().startsWith(p)) {
+        var item = new OpenRefineModel.SuggestItem();
+        item.id = prop.id;
+        item.name = prop.name;
+        resp.result.add(item);
+      }
+    }
+    return resp;
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/DefaultReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/DefaultReconciliationResource.java
@@ -1,0 +1,50 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.vocab.Datasets;
+import life.catalogue.cache.LatestDatasetKeyCache;
+import life.catalogue.config.MatchingConfig;
+import life.catalogue.es.suggest.NameUsageSuggestionService;
+import life.catalogue.matching.UsageMatcherFactory;
+
+import java.net.URI;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Default OpenRefine reconciliation endpoint pointing at the COL backbone, i.e. the latest public
+ * extended release of the COL project ({@link Datasets#COL}). The concrete release key is resolved
+ * per request so the bare {@code /reconcile} URL always tracks the current XR, while its manifest
+ * keeps advertising the stable {@code /reconcile} sub-service URLs.
+ */
+@Path("/reconcile")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class DefaultReconciliationResource extends AbstractReconciliationResource {
+  private final LatestDatasetKeyCache cache;
+
+  public DefaultReconciliationResource(MatchingConfig cfg, NameUsageSuggestionService suggestService, SqlSessionFactory factory,
+                                       UsageMatcherFactory matcherFactory, LatestDatasetKeyCache cache, URI apiURI, URI clbURI) {
+    super(cfg, suggestService, factory, matcherFactory, apiURI, clbURI);
+    this.cache = cache;
+  }
+
+  @Override
+  protected int resolveDatasetKey(int pathKey) {
+    Integer key = cache.getLatestRelease(Datasets.COL, true);
+    if (key == null) {
+      throw new NotFoundException("No COL extended release available to reconcile against");
+    }
+    return key;
+  }
+
+  @Override
+  protected String reconcileBaseUrl(int datasetKey) {
+    return apiBase() + "/reconcile";
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineMapper.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineMapper.java
@@ -1,0 +1,183 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.model.SimpleNameCached;
+import life.catalogue.api.model.SimpleNameClassified;
+import life.catalogue.api.vocab.MatchType;
+import life.catalogue.matching.UsageMatch;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.gbif.nameparser.api.Rank;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Pure mapping between the CoL matching engine and the OpenRefine reconciliation protocol.
+ * Kept free of HTTP and persistence concerns so it can be unit tested in isolation.
+ */
+public class OpenRefineMapper {
+  /** The single reconciliation type CoL exposes. */
+  public static final OpenRefineModel.Type TAXON_TYPE = new OpenRefineModel.Type("Taxon", "Taxon");
+
+  private OpenRefineMapper() {}
+
+  /** Score 0-100 derived from a names-index/usage match type. */
+  public static double score(MatchType type) {
+    if (type == null) return 0;
+    switch (type) {
+      case EXACT: return 100;
+      case VARIANT: return 98;
+      case CANONICAL: return 90;
+      case AMBIGUOUS: return 75;
+      case HIGHERRANK: return 50;
+      default: return 0; // NONE, UNSUPPORTED
+    }
+  }
+
+  /** Maps a usage match (primary + alternatives) to an OpenRefine result for a single query. */
+  public static OpenRefineModel.Result toResult(UsageMatch match) {
+    var result = new OpenRefineModel.Result();
+    if (match != null && match.isMatch()) {
+      // OpenRefine auto-matches a cell when a single candidate has match=true.
+      // Only do that for unambiguous exact hits.
+      boolean autoMatch = match.type == MatchType.EXACT;
+      result.result.add(toCandidate(match.usage, match.type, autoMatch));
+    }
+    if (match != null && match.alternatives != null) {
+      for (var alt : match.alternatives) {
+        result.result.add(toCandidate(alt, alt.getNamesIndexMatchType(), false));
+      }
+    }
+    return result;
+  }
+
+  static OpenRefineModel.Candidate toCandidate(SimpleNameClassified<SimpleNameCached> u, MatchType type, boolean match) {
+    var c = new OpenRefineModel.Candidate();
+    c.id = u.getId();
+    c.name = u.getLabel();
+    c.score = score(type);
+    c.match = match;
+    c.type.add(TAXON_TYPE);
+    return c;
+  }
+
+  /** Builds the service manifest for a dataset-scoped reconciliation endpoint. */
+  public static OpenRefineModel.Manifest manifest(int datasetKey, String apiReconcileUrl, String clbBaseUrl) {
+    var m = new OpenRefineModel.Manifest();
+    m.name = "Catalogue of Life — dataset " + datasetKey;
+    String taxonSpace = clbBaseUrl + "/dataset/" + datasetKey + "/taxon/";
+    m.identifierSpace = taxonSpace;
+    m.schemaSpace = taxonSpace;
+    m.defaultTypes.add(TAXON_TYPE);
+    m.view = new OpenRefineModel.View(clbBaseUrl + "/dataset/" + datasetKey + "/taxon/{{id}}");
+    m.suggest = new OpenRefineModel.SuggestServices();
+    m.suggest.entity = new OpenRefineModel.SuggestService(apiReconcileUrl, "/suggest/entity");
+    m.suggest.property = new OpenRefineModel.SuggestService(apiReconcileUrl, "/suggest/property");
+    m.extend = new OpenRefineModel.ExtendService(
+      new OpenRefineModel.PropertySettings(apiReconcileUrl, "/extend/propose")
+    );
+    return m;
+  }
+
+  /** The fixed catalogue of properties the data extension service can return for a matched taxon. */
+  public static final List<OpenRefineModel.ExtendProperty> EXTENSION_PROPERTIES = List.of(
+    new OpenRefineModel.ExtendProperty("scientificName", "scientific name"),
+    new OpenRefineModel.ExtendProperty("authorship", "authorship"),
+    new OpenRefineModel.ExtendProperty("rank", "rank"),
+    new OpenRefineModel.ExtendProperty("status", "status"),
+    new OpenRefineModel.ExtendProperty("nidx", "names index id"),
+    new OpenRefineModel.ExtendProperty("kingdom", "kingdom"),
+    new OpenRefineModel.ExtendProperty("phylum", "phylum"),
+    new OpenRefineModel.ExtendProperty("class", "class"),
+    new OpenRefineModel.ExtendProperty("order", "order"),
+    new OpenRefineModel.ExtendProperty("family", "family"),
+    new OpenRefineModel.ExtendProperty("genus", "genus")
+  );
+
+  /**
+   * Resolves a single data extension property for a matched usage. Returns null when the property
+   * is unknown or has no value for this usage.
+   */
+  public static String extendValue(SimpleNameClassified<SimpleNameCached> u, String propertyId) {
+    if (u == null || propertyId == null) return null;
+    switch (propertyId) {
+      case "scientificName": return u.getName();
+      case "authorship": return u.getAuthorship();
+      case "rank": return u.getRank() == null ? null : u.getRank().name().toLowerCase();
+      case "status": return u.getStatus() == null ? null : u.getStatus().name().toLowerCase();
+      case "nidx": return u.getNamesIndexId() == null ? null : String.valueOf(u.getNamesIndexId());
+      default:
+        Rank rank = parseRank(propertyId);
+        if (rank != null && u.getClassification() != null) {
+          var t = u.getByRank(rank);
+          return t == null ? null : t.getName();
+        }
+        return null;
+    }
+  }
+
+  private static Rank parseRank(String propertyId) {
+    try {
+      return Rank.valueOf(propertyId.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /** Builds the data extension response for the given ids/properties from already-loaded usages. */
+  public static OpenRefineModel.ExtendResponse buildExtendResponse(List<String> ids, List<String> propertyIds,
+                                                                   Map<String, SimpleNameClassified<SimpleNameCached>> usages) {
+    var resp = new OpenRefineModel.ExtendResponse();
+    for (String pid : propertyIds) {
+      resp.meta.add(new OpenRefineModel.ExtendProperty(pid, propertyName(pid)));
+    }
+    for (String id : ids) {
+      var usage = usages.get(id);
+      var row = new LinkedHashMap<String, List<OpenRefineModel.Cell>>();
+      for (String pid : propertyIds) {
+        String value = usage == null ? null : extendValue(usage, pid);
+        row.put(pid, value == null ? List.of() : List.of(new OpenRefineModel.Cell(value)));
+      }
+      resp.rows.put(id, row);
+    }
+    return resp;
+  }
+
+  private static String propertyName(String pid) {
+    return EXTENSION_PROPERTIES.stream()
+      .filter(p -> p.id.equals(pid))
+      .map(p -> p.name)
+      .findFirst()
+      .orElse(pid);
+  }
+
+  /** Maps name usage suggestions to an OpenRefine suggest/entity response. */
+  public static OpenRefineModel.SuggestResponse toSuggestResponse(List<life.catalogue.api.search.NameUsageSuggestion> suggestions) {
+    var resp = new OpenRefineModel.SuggestResponse();
+    if (suggestions != null) {
+      for (var s : suggestions) {
+        var item = new OpenRefineModel.SuggestItem();
+        item.id = s.getUsageId();
+        item.name = s.getMatch();
+        item.description = s.getSuggestion();
+        item.type.add(TAXON_TYPE);
+        resp.result.add(item);
+      }
+    }
+    return resp;
+  }
+
+  /**
+   * Parses the OpenRefine {@code queries} payload, a JSON object keyed by query id, into a map.
+   */
+  public static Map<String, OpenRefineModel.Query> parseQueries(String json, ObjectMapper om) throws IOException {
+    if (json == null || json.isBlank()) {
+      return new LinkedHashMap<>();
+    }
+    return om.readValue(json, new TypeReference<LinkedHashMap<String, OpenRefineModel.Query>>() {});
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/OpenRefineModel.java
@@ -1,0 +1,191 @@
+package life.catalogue.resources.matching.openrefine;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Data transfer objects for the OpenRefine Reconciliation Service API (spec version 0.2).
+ * See https://reconciliation-api.github.io/specs/0.2/
+ *
+ * These are simple, Jackson-serializable holders. The mapping from the CoL matching/parsing
+ * engines onto these structures lives in {@link OpenRefineMapper}.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OpenRefineModel {
+
+  /** A reconciliation type, e.g. the single "Taxon" type CoL exposes. */
+  public static class Type {
+    public String id;
+    public String name;
+
+    public Type() {}
+
+    public Type(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+  }
+
+  /** A single reconciliation candidate returned for a query. */
+  public static class Candidate {
+    public String id;
+    public String name;
+    public double score;
+    public boolean match;
+    public List<Type> type = new ArrayList<>();
+  }
+
+  /** The result wrapper for a single query: {@code { "result": [ ... ] }}. */
+  public static class Result {
+    public List<Candidate> result = new ArrayList<>();
+  }
+
+  /** An incoming reconciliation query as sent by OpenRefine. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class Query {
+    public String query;
+    public String type;
+    public Integer limit;
+    public List<QueryProperty> properties;
+  }
+
+  /** A property hint attached to an incoming query, e.g. {@code {"pid":"rank","v":"species"}}. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class QueryProperty {
+    public String pid;
+    public JsonNode v;
+  }
+
+  /** The service manifest returned on a GET to the reconciliation endpoint root. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class Manifest {
+    public List<String> versions = List.of("0.1", "0.2");
+    public String name;
+    public String identifierSpace;
+    public String schemaSpace;
+    public List<Type> defaultTypes = new ArrayList<>();
+    public View view;
+    public SuggestServices suggest;
+    public ExtendService extend;
+  }
+
+  public static class View {
+    public String url;
+
+    public View() {}
+
+    public View(String url) {
+      this.url = url;
+    }
+  }
+
+  public static class SuggestServices {
+    public SuggestService entity;
+    public SuggestService property;
+  }
+
+  public static class SuggestService {
+    public String service_url;
+    public String service_path;
+
+    public SuggestService() {}
+
+    public SuggestService(String service_url, String service_path) {
+      this.service_url = service_url;
+      this.service_path = service_path;
+    }
+  }
+
+  public static class ExtendService {
+    public PropertySettings propose_properties;
+
+    public ExtendService() {}
+
+    public ExtendService(PropertySettings propose_properties) {
+      this.propose_properties = propose_properties;
+    }
+  }
+
+  public static class PropertySettings {
+    public String service_url;
+    public String service_path;
+
+    public PropertySettings() {}
+
+    public PropertySettings(String service_url, String service_path) {
+      this.service_url = service_url;
+      this.service_path = service_path;
+    }
+  }
+
+  // ---- Data extension ----
+
+  /** Incoming data extension request: {@code { "ids": [...], "properties": [ {"id": ...} ] }}. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class ExtendQuery {
+    public List<String> ids = new ArrayList<>();
+    public List<ExtendProperty> properties = new ArrayList<>();
+  }
+
+  public static class ExtendProperty {
+    public String id;
+    public String name;
+
+    public ExtendProperty() {}
+
+    public ExtendProperty(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+  }
+
+  /** A single value cell in a data extension response. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class Cell {
+    public String str;
+
+    public Cell() {}
+
+    public Cell(String str) {
+      this.str = str;
+    }
+  }
+
+  /** Data extension response: column metadata plus per-id, per-property value cells. */
+  public static class ExtendResponse {
+    public List<ExtendProperty> meta = new ArrayList<>();
+    // id -> (propertyId -> cells)
+    public Map<String, Map<String, List<Cell>>> rows = new LinkedHashMap<>();
+  }
+
+  // ---- Suggest ----
+
+  public static class SuggestResponse {
+    public List<SuggestItem> result = new ArrayList<>();
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class SuggestItem {
+    public String id;
+    public String name;
+    public String description;
+    public List<Type> type = new ArrayList<>();
+  }
+
+  /** Response of the extend/propose service listing the properties offered for data extension. */
+  public static class ProposeResponse {
+    public String type = "Taxon";
+    public List<ExtendProperty> properties;
+
+    public ProposeResponse() {}
+
+    public ProposeResponse(List<ExtendProperty> properties) {
+      this.properties = properties;
+    }
+  }
+}

--- a/webservice/src/main/java/life/catalogue/resources/matching/openrefine/ReconciliationResource.java
+++ b/webservice/src/main/java/life/catalogue/resources/matching/openrefine/ReconciliationResource.java
@@ -1,0 +1,29 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.config.MatchingConfig;
+import life.catalogue.es.suggest.NameUsageSuggestionService;
+import life.catalogue.matching.UsageMatcherFactory;
+
+import java.net.URI;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Dataset-scoped OpenRefine reconciliation endpoint, reconciling against any dataset or release.
+ * All behaviour is inherited; this class only binds the dataset-scoped {@code @Path}.
+ */
+@Path("/dataset/{key}/reconcile")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ReconciliationResource extends AbstractReconciliationResource {
+
+  public ReconciliationResource(MatchingConfig cfg, NameUsageSuggestionService suggestService, SqlSessionFactory factory,
+                                UsageMatcherFactory matcherFactory, URI apiURI, URI clbURI) {
+    super(cfg, suggestService, factory, matcherFactory, apiURI, clbURI);
+  }
+}

--- a/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineMapperTest.java
+++ b/webservice/src/test/java/life/catalogue/resources/matching/openrefine/OpenRefineMapperTest.java
@@ -1,0 +1,155 @@
+package life.catalogue.resources.matching.openrefine;
+
+import life.catalogue.api.jackson.ApiModule;
+import life.catalogue.api.model.SimpleNameCached;
+import life.catalogue.api.model.SimpleNameClassified;
+import life.catalogue.api.vocab.MatchType;
+import life.catalogue.api.vocab.TaxonomicStatus;
+import life.catalogue.matching.UsageMatch;
+
+import org.gbif.nameparser.api.NomCode;
+import org.gbif.nameparser.api.Rank;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OpenRefineMapperTest {
+
+  static SimpleNameClassified<SimpleNameCached> name(String id, String name, String authorship, MatchType nidxType) {
+    var sn = SimpleNameClassified.snc(id, Rank.SPECIES, NomCode.ZOOLOGICAL, TaxonomicStatus.ACCEPTED, name, authorship);
+    sn.setNamesIndexMatchType(nidxType);
+    return sn;
+  }
+
+  @Test
+  public void scoreOrdering() {
+    assertEquals(100.0, OpenRefineMapper.score(MatchType.EXACT), 0.0001);
+    assertEquals(0.0, OpenRefineMapper.score(MatchType.NONE), 0.0001);
+    assertEquals(0.0, OpenRefineMapper.score(null), 0.0001);
+    assertTrue(OpenRefineMapper.score(MatchType.EXACT) > OpenRefineMapper.score(MatchType.VARIANT));
+    assertTrue(OpenRefineMapper.score(MatchType.VARIANT) > OpenRefineMapper.score(MatchType.CANONICAL));
+    assertTrue(OpenRefineMapper.score(MatchType.CANONICAL) > OpenRefineMapper.score(MatchType.AMBIGUOUS));
+    assertTrue(OpenRefineMapper.score(MatchType.AMBIGUOUS) > OpenRefineMapper.score(MatchType.HIGHERRANK));
+    assertTrue(OpenRefineMapper.score(MatchType.HIGHERRANK) > 0);
+  }
+
+  @Test
+  public void exactMatchIsAutoMatched() {
+    var usage = name("42", "Puma concolor", "(Linnaeus, 1771)", MatchType.EXACT);
+    var match = UsageMatch.match(MatchType.EXACT, usage, 3, null);
+
+    var result = OpenRefineMapper.toResult(match);
+
+    assertEquals(1, result.result.size());
+    var c = result.result.get(0);
+    assertEquals("42", c.id);
+    assertEquals("Puma concolor (Linnaeus, 1771)", c.name);
+    assertEquals(100.0, c.score, 0.0001);
+    assertTrue(c.match);
+    assertEquals(1, c.type.size());
+    assertEquals("Taxon", c.type.get(0).id);
+  }
+
+  @Test
+  public void ambiguousIsNotAutoMatched() {
+    var usage = name("1", "Aus", null, MatchType.AMBIGUOUS);
+    var alt = name("2", "Aus", null, MatchType.AMBIGUOUS);
+    var match = UsageMatch.match(MatchType.AMBIGUOUS, usage, 3, List.of(alt));
+
+    var result = OpenRefineMapper.toResult(match);
+
+    assertEquals(2, result.result.size());
+    assertFalse("ambiguous primary must not auto-match", result.result.get(0).match);
+    assertFalse(result.result.get(1).match);
+  }
+
+  @Test
+  public void noMatchYieldsEmptyResult() {
+    var result = OpenRefineMapper.toResult(UsageMatch.empty(3));
+    assertTrue(result.result.isEmpty());
+  }
+
+  @Test
+  public void manifestHasDatasetScopedUrls() {
+    var m = OpenRefineMapper.manifest(3, "https://api.checklistbank.org/dataset/3/reconcile", "https://www.checklistbank.org");
+
+    assertTrue(m.versions.contains("0.2"));
+    assertTrue(m.name.contains("Catalogue of Life"));
+    assertTrue(m.identifierSpace.contains("/dataset/3/taxon/"));
+    assertTrue(m.view.url.contains("/dataset/3/taxon/"));
+    assertTrue(m.view.url.contains("{{id}}"));
+    assertEquals("Taxon", m.defaultTypes.get(0).id);
+    assertNotNull(m.suggest.entity);
+    assertNotNull(m.extend);
+  }
+
+  @Test
+  public void extendValuesFromUsageAndClassification() {
+    var usage = name("42", "Puma concolor", "(Linnaeus, 1771)", MatchType.EXACT);
+    usage.setNamesIndexId(987);
+    var family = SimpleNameClassified.snc("f1", Rank.FAMILY, NomCode.ZOOLOGICAL, TaxonomicStatus.ACCEPTED, "Felidae", null);
+    usage.setClassification(List.of(family));
+
+    assertEquals("Puma concolor", OpenRefineMapper.extendValue(usage, "scientificName"));
+    assertEquals("(Linnaeus, 1771)", OpenRefineMapper.extendValue(usage, "authorship"));
+    assertEquals("species", OpenRefineMapper.extendValue(usage, "rank"));
+    assertEquals("987", OpenRefineMapper.extendValue(usage, "nidx"));
+    assertEquals("Felidae", OpenRefineMapper.extendValue(usage, "family"));
+    assertNull(OpenRefineMapper.extendValue(usage, "kingdom"));
+    assertNull(OpenRefineMapper.extendValue(usage, "bogus"));
+  }
+
+  @Test
+  public void buildExtendResponseFillsRequestedColumns() {
+    var usage = name("42", "Puma concolor", "(Linnaeus, 1771)", MatchType.EXACT);
+    var family = SimpleNameClassified.snc("f1", Rank.FAMILY, NomCode.ZOOLOGICAL, TaxonomicStatus.ACCEPTED, "Felidae", null);
+    usage.setClassification(List.of(family));
+
+    var resp = OpenRefineMapper.buildExtendResponse(
+      List.of("42", "missing"),
+      List.of("authorship", "family"),
+      Map.of("42", usage));
+
+    // meta carries human readable names from the property catalog
+    assertEquals(2, resp.meta.size());
+    assertEquals("authorship", resp.meta.get(0).id);
+
+    // matched id has the values
+    assertEquals("(Linnaeus, 1771)", resp.rows.get("42").get("authorship").get(0).str);
+    assertEquals("Felidae", resp.rows.get("42").get("family").get(0).str);
+
+    // unknown id is still present with empty cells
+    assertTrue(resp.rows.containsKey("missing"));
+    assertTrue(resp.rows.get("missing").get("authorship").isEmpty());
+  }
+
+  @Test
+  public void toSuggestResponseMapsEntities() {
+    var s = new life.catalogue.api.search.NameUsageSuggestion();
+    s.setUsageId("u1");
+    s.setMatch("Puma concolor");
+    s.setRank(Rank.SPECIES);
+    s.setStatus(TaxonomicStatus.ACCEPTED);
+
+    var resp = OpenRefineMapper.toSuggestResponse(List.of(s));
+
+    assertEquals(1, resp.result.size());
+    assertEquals("u1", resp.result.get(0).id);
+    assertEquals("Puma concolor", resp.result.get(0).name);
+    assertEquals("Taxon", resp.result.get(0).type.get(0).id);
+  }
+
+  @Test
+  public void parseQueriesParsesBatch() throws Exception {
+    String json = "{\"q0\":{\"query\":\"Puma concolor\"},\"q1\":{\"query\":\"Aus bus\",\"limit\":3}}";
+    Map<String, OpenRefineModel.Query> queries = OpenRefineMapper.parseQueries(json, ApiModule.MAPPER);
+
+    assertEquals(2, queries.size());
+    assertEquals("Puma concolor", queries.get("q0").query);
+    assertEquals(Integer.valueOf(3), queries.get("q1").limit);
+  }
+}


### PR DESCRIPTION
## What

Exposes CoL name matching to [OpenRefine](https://openrefine.org) via the [Reconciliation Service API v0.2](https://reconciliation-api.github.io/specs/0.2/), so taxonomists can clean and enrich tabular name data without writing code. Parsers are surfaced as documented URL-fetch recipes.

OpenRefine has two native extension points and CoL maps onto both:

| OpenRefine feature | CoL backend | Result |
|---|---|---|
| **Reconciliation** | the name matcher (`UsageMatcher` / name index) | match a name column to CoL taxa, with scores + auto-match |
| **Data Extension** | matched taxon + classification | pull authorship, rank, status, nidx id, higher ranks as columns |
| *Add column by fetching URLs* | existing `/parser/*` endpoints | run any parser (name, date, rank, country, …) over a column |

## Endpoints

- `GET /dataset/{key}/reconcile` — service manifest
- `POST /dataset/{key}/reconcile` — batch reconciliation (`queries` form field or JSON body)
- `POST /dataset/{key}/reconcile/extend` + `GET …/extend/propose` — data extension
- `GET …/suggest/entity` / `…/suggest/property` — autocomplete aids
- `…/reconcile` (no `/dataset/{key}`) — COL backbone, resolving the latest COL extended release per request

`{key}` accepts the usual aliases (`3LXR`, `3LR`, `COL2024`, `gbif-<uuid>`) via the existing rewrite filter.

## Design

- `OpenRefineModel` / `OpenRefineMapper`: protocol DTOs + pure mapping (scoring, `UsageMatch`→candidates, manifest, extension, suggest) — unit tested.
- `AbstractReconciliationResource`: all endpoint logic; reconciliation reuses the **exact** matcher path of `/dataset/{key}/match/nameusage` (`AbstractMatchingJob.interpretAndMatch`), only reshaping request/response.
- Two thin `@Path` subclasses: `ReconciliationResource` (any dataset) and `DefaultReconciliationResource` (COL backbone via `LatestDatasetKeyCache.getLatestRelease(Datasets.COL, true)`).
- Registered on `WsServer` next to `NameUsageMatchingResource`. CORS already covers it (no JSONP needed).
- `OPENREFINE.md`: setup, property hints, extension columns, parser recipes.

## Testing

- `OpenRefineMapperTest` — 9 unit tests (TDD; scoring, auto-match vs candidate list, manifest URLs, query parsing, extension rows, suggest mapping). Swagger generation verified.
- The live matcher/names-index path was **not** exercised locally (no complete nidx locally). To verify end-to-end on dev:
  - `GET https://api.dev.checklistbank.org/reconcile` → manifest
  - add that URL in OpenRefine → "guess types" succeeds → reconcile a name column.

## Notes

- Exposed on the rw server (where `matcherFactory` lives), consistent with the existing match endpoint; surfacing it on the read-only/matching server is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)